### PR TITLE
Response formatting

### DIFF
--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -1,11 +1,15 @@
 require 'test_helper'
 
 class ArtefactRequestTest < GovUkContentApiTest
+  def assert_status_field(expected, response)
+    assert_equal expected, JSON.parse(response.body)["_response_info"]["status"]
+  end
+
   should "return 404 if artefact not found" do
     Artefact.expects(:where).with(slug: 'bad-artefact').returns([])
     get '/bad-artefact.json'
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["status"]
+    assert_status_field "not found", last_response
   end
 
   should "return 404 if artefact is publication but never published" do
@@ -17,7 +21,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/unpublished-artefact.json'
 
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["status"]
+    assert_status_field "not found", last_response
   end
 
   should "return 410 if artefact is publication but only archived" do
@@ -29,7 +33,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/archived-artefact.json'
 
     assert_equal 410, last_response.status
-    assert_equal 'gone', JSON.parse(last_response.body)["status"]
+    assert_status_field "gone", last_response
   end
 
   should "return publication data if published" do
@@ -44,8 +48,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
     
-    assert_equal 'ok', parsed_response["status"]
-    assert_equal "<h1>Important information</h1>\n", parsed_response["result"]["fields"]["body"]
+    assert_status_field "ok", last_response
+    assert_equal "<h1>Important information</h1>\n", parsed_response["fields"]["body"]
   end
 
   should "convert artefact body and part bodies to html" do
@@ -60,8 +64,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "<h1>Important information</h1>\n", parsed_response["result"]["fields"]["body"]
-    assert_equal "<h2>Header 2</h2>\n", parsed_response["result"]["fields"]["parts"][0]["body"]
+    assert_equal "<h1>Important information</h1>\n", parsed_response["fields"]["body"]
+    assert_equal "<h2>Header 2</h2>\n", parsed_response["fields"]["parts"][0]["body"]
   end
 
   should "return govspeak in artefact body and part bodies if requested" do
@@ -76,8 +80,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "# Important information", parsed_response["result"]["fields"]["body"]
-    assert_equal "## Header 2", parsed_response["result"]["fields"]["parts"][0]["body"]
+    assert_equal "# Important information", parsed_response["fields"]["body"]
+    assert_equal "## Header 2", parsed_response["fields"]["parts"][0]["body"]
   end
 
   should "return related artefact slugs in related_artefact_ids" do
@@ -96,8 +100,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
     
-    assert_equal 'ok', parsed_response["status"]
-    assert_equal ["related-artefact-1", "related-artefact-2"], parsed_response["result"]["related_artefact_ids"]
+    assert_status_field "ok", last_response
+    assert_equal ["related-artefact-1", "related-artefact-2"], parsed_response["related_artefact_ids"]
   end
 
   should "not look for edition if publisher not owner" do
@@ -108,6 +112,6 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/smart-answer.json'
 
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_status_field "ok", last_response
   end
 end

--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -5,7 +5,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     Artefact.expects(:where).with(slug: 'bad-artefact').returns([])
     get '/bad-artefact.json'
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'not found', JSON.parse(last_response.body)["status"]
   end
 
   should "return 404 if artefact is publication but never published" do
@@ -17,7 +17,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/unpublished-artefact.json'
 
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'not found', JSON.parse(last_response.body)["status"]
   end
 
   should "return 410 if artefact is publication but only archived" do
@@ -29,7 +29,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/archived-artefact.json'
 
     assert_equal 410, last_response.status
-    assert_equal 'gone', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'gone', JSON.parse(last_response.body)["status"]
   end
 
   should "return publication data if published" do
@@ -44,8 +44,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
     
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert_equal "<h1>Important information</h1>\n", parsed_response["response"]["result"]["fields"]["body"]
+    assert_equal 'ok', parsed_response["status"]
+    assert_equal "<h1>Important information</h1>\n", parsed_response["result"]["fields"]["body"]
   end
 
   should "convert artefact body and part bodies to html" do
@@ -60,8 +60,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "<h1>Important information</h1>\n", parsed_response["response"]["result"]["fields"]["body"]
-    assert_equal "<h2>Header 2</h2>\n", parsed_response["response"]["result"]["fields"]["parts"][0]["body"]
+    assert_equal "<h1>Important information</h1>\n", parsed_response["result"]["fields"]["body"]
+    assert_equal "<h2>Header 2</h2>\n", parsed_response["result"]["fields"]["parts"][0]["body"]
   end
 
   should "return govspeak in artefact body and part bodies if requested" do
@@ -76,8 +76,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "# Important information", parsed_response["response"]["result"]["fields"]["body"]
-    assert_equal "## Header 2", parsed_response["response"]["result"]["fields"]["parts"][0]["body"]
+    assert_equal "# Important information", parsed_response["result"]["fields"]["body"]
+    assert_equal "## Header 2", parsed_response["result"]["fields"]["parts"][0]["body"]
   end
 
   should "return related artefact slugs in related_artefact_ids" do
@@ -96,8 +96,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
     
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert_equal ["related-artefact-1", "related-artefact-2"], parsed_response["response"]["result"]["related_artefact_ids"]
+    assert_equal 'ok', parsed_response["status"]
+    assert_equal ["related-artefact-1", "related-artefact-2"], parsed_response["result"]["related_artefact_ids"]
   end
 
   should "not look for edition if publisher not owner" do
@@ -108,6 +108,6 @@ class ArtefactRequestTest < GovUkContentApiTest
     get '/smart-answer.json'
 
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'ok', JSON.parse(last_response.body)["status"]
   end
 end

--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -47,7 +47,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    
+
     assert_status_field "ok", last_response
     assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
   end
@@ -99,7 +99,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    
+
     assert_status_field "ok", last_response
     assert_equal ["related-artefact-1", "related-artefact-2"], parsed_response["related_artefact_ids"]
   end

--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -49,7 +49,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     assert last_response.ok?
     
     assert_status_field "ok", last_response
-    assert_equal "<h1>Important information</h1>\n", parsed_response["fields"]["body"]
+    assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
   end
 
   should "convert artefact body and part bodies to html" do
@@ -64,8 +64,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "<h1>Important information</h1>\n", parsed_response["fields"]["body"]
-    assert_equal "<h2>Header 2</h2>\n", parsed_response["fields"]["parts"][0]["body"]
+    assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
+    assert_equal "<h2>Header 2</h2>\n", parsed_response["details"]["parts"][0]["body"]
   end
 
   should "return govspeak in artefact body and part bodies if requested" do
@@ -80,8 +80,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
 
-    assert_equal "# Important information", parsed_response["fields"]["body"]
-    assert_equal "## Header 2", parsed_response["fields"]["parts"][0]["body"]
+    assert_equal "# Important information", parsed_response["details"]["body"]
+    assert_equal "## Header 2", parsed_response["details"]["parts"][0]["body"]
   end
 
   should "return related artefact slugs in related_artefact_ids" do

--- a/test/integration/artefact_with_tags_request_test.rb
+++ b/test/integration/artefact_with_tags_request_test.rb
@@ -7,7 +7,7 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     get "/with_tag.json?tag=farmers"
 
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'not found', JSON.parse(last_response.body)["status"]
   end
 
   should "return the standard response even if zero results" do
@@ -20,8 +20,8 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert_equal 0, parsed_response["response"]["total"]
+    assert_equal 'ok', parsed_response["status"]
+    assert_equal 0, parsed_response["total"]
   end
 
 
@@ -35,7 +35,7 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     get "/with_tag.json?tag=farmers"
 
     assert last_response.ok?
-    assert_equal 1, JSON.parse(last_response.body)["response"]["results"].count
+    assert_equal 1, JSON.parse(last_response.body)["results"].count
   end
 
   should "exclude unpublished publisher items" do
@@ -53,7 +53,7 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     get "/with_tag.json?tag=farmers"
 
     assert last_response.ok?, "request failed: #{last_response.status}"
-    assert_equal 2, JSON.parse(last_response.body)["response"]["results"].count
+    assert_equal 2, JSON.parse(last_response.body)["results"].count
   end
 
   should "allow filtering by multiple tags" do
@@ -68,6 +68,6 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
 
     get "/with_tag.json?tag=farmers,business"
     assert last_response.ok?
-    assert_equal 1, JSON.parse(last_response.body)["response"]["results"].count
+    assert_equal 1, JSON.parse(last_response.body)["results"].count
   end
 end

--- a/test/integration/artefact_with_tags_request_test.rb
+++ b/test/integration/artefact_with_tags_request_test.rb
@@ -7,7 +7,7 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     get "/with_tag.json?tag=farmers"
 
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["status"]
+    assert_status_field "not found", last_response
   end
 
   should "return the standard response even if zero results" do
@@ -20,7 +20,7 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["status"]
+    assert_status_field "ok", last_response
     assert_equal 0, parsed_response["total"]
   end
 

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -35,14 +35,14 @@ class FormatsRequestTest < GovUkContentApiTest
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section']
 
-    _assert_has_expected_fields(fields, expected_fields)    
+    _assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>Important batman information</p>\n", fields["body"]
   end
 
   should "business_support_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman', owning_app: 'publisher', sections: [@tag1.tag_id])
-    business_support = FactoryGirl.create(:business_support_edition, slug: artefact.slug, 
-                                short_description: "No policeman's going to give the Batmobile a ticket", min_value: 100, 
+    business_support = FactoryGirl.create(:business_support_edition, slug: artefact.slug,
+                                short_description: "No policeman's going to give the Batmobile a ticket", min_value: 100,
                                 max_value: 1000, panopticon_id: artefact.id, state: 'published')
     business_support.parts[0].body = "Lalalala"
     business_support.save!
@@ -54,7 +54,7 @@ class FormatsRequestTest < GovUkContentApiTest
     _assert_base_response_info(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['alternative_title', 'overview', 'section', 
+    expected_fields = ['alternative_title', 'overview', 'section',
                         'short_description', 'min_value', 'max_value', 'parts']
     _assert_has_expected_fields(fields, expected_fields)
     assert_false fields.has_key?('body')
@@ -64,7 +64,7 @@ class FormatsRequestTest < GovUkContentApiTest
 
   should "guide_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman', owning_app: 'publisher', sections: [@tag1.tag_id])
-    guide_edition = FactoryGirl.create(:guide_edition_with_two_govspeak_parts, slug: artefact.slug, 
+    guide_edition = FactoryGirl.create(:guide_edition_with_two_govspeak_parts, slug: artefact.slug,
                                 panopticon_id: artefact.id, state: 'published')
     guide_edition.save!
 
@@ -86,7 +86,7 @@ class FormatsRequestTest < GovUkContentApiTest
 
   should "programme_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman', owning_app: 'publisher', sections: [@tag1.tag_id])
-    programme_edition = FactoryGirl.create(:programme_edition, slug: artefact.slug, 
+    programme_edition = FactoryGirl.create(:programme_edition, slug: artefact.slug,
                                 panopticon_id: artefact.id, state: 'published')
     programme_edition.save!
 
@@ -127,7 +127,7 @@ class FormatsRequestTest < GovUkContentApiTest
 
   should "licence_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman-licence', owning_app: 'publisher', sections: [@tag1.tag_id])
-    licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Batman licence', 
+    licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Batman licence',
                                 licence_overview: 'Not just anyone can be Batman', panopticon_id: artefact.id, state: 'published')
     get '/batman-licence.json'
     parsed_response = JSON.parse(last_response.body)
@@ -157,7 +157,7 @@ class FormatsRequestTest < GovUkContentApiTest
     _assert_base_response_info(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['alternative_title', 'section', 'lgsl_code', 'lgil_override', 'introduction', 'more_information', 
+    expected_fields = ['alternative_title', 'section', 'lgsl_code', 'lgil_override', 'introduction', 'more_information',
                         'minutes_to_complete', 'expectation_ids']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -166,7 +166,7 @@ class FormatsRequestTest < GovUkContentApiTest
   should "transaction_edition" do
     expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-transaction', owning_app: 'publisher', sections: [@tag1.tag_id])
-    transaction_edition = FactoryGirl.create(:transaction_edition, slug: artefact.slug, 
+    transaction_edition = FactoryGirl.create(:transaction_edition, slug: artefact.slug,
                                 expectation_ids: [expectation.id], minutes_to_complete: 3,
                                 panopticon_id: artefact.id, state: 'published')
     get '/batman-transaction.json'
@@ -176,7 +176,7 @@ class FormatsRequestTest < GovUkContentApiTest
     _assert_base_response_info(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['alternate_methods', 'section', 'will_continue_on', 'link', 'introduction', 'more_information', 
+    expected_fields = ['alternate_methods', 'section', 'will_continue_on', 'link', 'introduction', 'more_information',
                         'expectation_ids']
 
     _assert_has_expected_fields(fields, expected_fields)

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -9,10 +9,10 @@ class FormatsRequestTest < GovUkContentApiTest
   end
 
   def _assert_base_response_info(parsed_response)
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert parsed_response["response"]["result"].has_key?('title')
-    assert parsed_response["response"]["result"].has_key?('id')
-    assert parsed_response["response"]["result"].has_key?('tag_ids')
+    assert_equal 'ok', parsed_response["status"]
+    assert parsed_response["result"].has_key?('title')
+    assert parsed_response["result"].has_key?('id')
+    assert parsed_response["result"].has_key?('tag_ids')
   end
 
   def _assert_has_expected_fields(parsed_response, fields)
@@ -31,7 +31,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section']
 
@@ -53,7 +53,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 
                         'short_description', 'min_value', 'max_value', 'parts']
     _assert_has_expected_fields(fields, expected_fields)
@@ -74,7 +74,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -96,7 +96,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -115,7 +115,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section', 'video_url', 'video_summary']
 
@@ -135,7 +135,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternative_title', 'section', 'licence_overview', 'licence_short_description', 'licence_identifier']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -156,7 +156,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternative_title', 'section', 'lgsl_code', 'lgil_override', 'introduction', 'more_information', 
                         'minutes_to_complete', 'expectation_ids']
 
@@ -175,7 +175,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['alternate_methods', 'section', 'will_continue_on', 'link', 'introduction', 'more_information', 
                         'expectation_ids']
 
@@ -193,7 +193,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["response"]["result"]["fields"]
+    fields = parsed_response["result"]["fields"]
     expected_fields = ['section', 'introduction', 'more_information', 'place_type', 'expectation_ids']
 
     _assert_has_expected_fields(fields, expected_fields)

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -31,7 +31,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section']
 
@@ -53,7 +53,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'overview', 'section', 
                         'short_description', 'min_value', 'max_value', 'parts']
     _assert_has_expected_fields(fields, expected_fields)
@@ -74,7 +74,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -96,7 +96,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -115,7 +115,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section', 'video_url', 'video_summary']
 
@@ -135,7 +135,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'section', 'licence_overview', 'licence_short_description', 'licence_identifier']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -156,7 +156,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'section', 'lgsl_code', 'lgil_override', 'introduction', 'more_information', 
                         'minutes_to_complete', 'expectation_ids']
 
@@ -175,7 +175,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['alternate_methods', 'section', 'will_continue_on', 'link', 'introduction', 'more_information', 
                         'expectation_ids']
 
@@ -193,7 +193,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["fields"]
+    fields = parsed_response["details"]
     expected_fields = ['section', 'introduction', 'more_information', 'place_type', 'expectation_ids']
 
     _assert_has_expected_fields(fields, expected_fields)

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -9,10 +9,10 @@ class FormatsRequestTest < GovUkContentApiTest
   end
 
   def _assert_base_response_info(parsed_response)
-    assert_equal 'ok', parsed_response["status"]
-    assert parsed_response["result"].has_key?('title')
-    assert parsed_response["result"].has_key?('id')
-    assert parsed_response["result"].has_key?('tag_ids')
+    assert_equal 'ok', parsed_response["_response_info"]["status"]
+    assert parsed_response.has_key?('title')
+    assert parsed_response.has_key?('id')
+    assert parsed_response.has_key?('tag_ids')
   end
 
   def _assert_has_expected_fields(parsed_response, fields)
@@ -31,7 +31,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section']
 
@@ -53,7 +53,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 
                         'short_description', 'min_value', 'max_value', 'parts']
     _assert_has_expected_fields(fields, expected_fields)
@@ -74,7 +74,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -96,7 +96,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternative_title', 'overview', 'section', 'parts']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -115,7 +115,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
 
     expected_fields = ['alternative_title', 'overview', 'body', 'section', 'video_url', 'video_summary']
 
@@ -135,7 +135,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternative_title', 'section', 'licence_overview', 'licence_short_description', 'licence_identifier']
 
     _assert_has_expected_fields(fields, expected_fields)
@@ -156,7 +156,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternative_title', 'section', 'lgsl_code', 'lgil_override', 'introduction', 'more_information', 
                         'minutes_to_complete', 'expectation_ids']
 
@@ -175,7 +175,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['alternate_methods', 'section', 'will_continue_on', 'link', 'introduction', 'more_information', 
                         'expectation_ids']
 
@@ -193,7 +193,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert last_response.ok?
     _assert_base_response_info(parsed_response)
 
-    fields = parsed_response["result"]["fields"]
+    fields = parsed_response["fields"]
     expected_fields = ['section', 'introduction', 'more_information', 'place_type', 'expectation_ids']
 
     _assert_has_expected_fields(fields, expected_fields)

--- a/test/integration/search_request_test.rb
+++ b/test/integration/search_request_test.rb
@@ -11,7 +11,7 @@ class SearchRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["status"]
+    assert_status_field "ok", last_response
     assert_equal 2, parsed_response["total"]
     assert_equal 2, parsed_response["results"].count
     assert_equal 'Result 1', parsed_response["results"].first['title']
@@ -24,7 +24,7 @@ class SearchRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["status"]
+    assert_status_field "ok", last_response
     assert_equal 0, parsed_response["total"]
   end
 

--- a/test/integration/search_request_test.rb
+++ b/test/integration/search_request_test.rb
@@ -11,10 +11,10 @@ class SearchRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert_equal 2, parsed_response["response"]["total"]
-    assert_equal 2, parsed_response["response"]["results"].count
-    assert_equal 'Result 1', parsed_response["response"]["results"].first['title']
+    assert_equal 'ok', parsed_response["status"]
+    assert_equal 2, parsed_response["total"]
+    assert_equal 2, parsed_response["results"].count
+    assert_equal 'Result 1', parsed_response["results"].first['title']
   end
 
   should "return the standard response even if zero results" do
@@ -24,8 +24,8 @@ class SearchRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert_equal 'ok', parsed_response["response"]["status"]
-    assert_equal 0, parsed_response["response"]["total"]
+    assert_equal 'ok', parsed_response["status"]
+    assert_equal 0, parsed_response["total"]
   end
 
   should "return 503 if no solr connection" do

--- a/test/integration/tag_request_test.rb
+++ b/test/integration/tag_request_test.rb
@@ -8,7 +8,7 @@ class TagRequestTest < GovUkContentApiTest
     ])
     get "/tags.json"
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_status_field "ok", last_response
     assert_equal 2, JSON.parse(last_response.body)['results'].count
   end
 
@@ -18,7 +18,7 @@ class TagRequestTest < GovUkContentApiTest
     ])
     get "/tags.json?type=Section"
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_status_field "ok", last_response
     assert_equal 1, JSON.parse(last_response.body)['results'].count
   end
 
@@ -27,14 +27,14 @@ class TagRequestTest < GovUkContentApiTest
     Tag.expects(:where).with(tag_id: 'good-tag').returns([fake_tag])
     get '/tags/good-tag.json'
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["status"]
-    assert_equal 'Lots to say for myself', JSON.parse(last_response.body)['result']['fields']['description']
+    assert_status_field "ok", last_response
+    assert_equal 'Lots to say for myself', JSON.parse(last_response.body)['fields']['description']
   end
 
   should "return 404 if specific tag not found" do
     Tag.expects(:where).with(tag_id: 'bad-tag').returns([])
     get '/tags/bad-tag.json'
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["status"]
+    assert_status_field "not found", last_response
   end
 end

--- a/test/integration/tag_request_test.rb
+++ b/test/integration/tag_request_test.rb
@@ -28,7 +28,7 @@ class TagRequestTest < GovUkContentApiTest
     get '/tags/good-tag.json'
     assert last_response.ok?
     assert_status_field "ok", last_response
-    assert_equal 'Lots to say for myself', JSON.parse(last_response.body)['fields']['description']
+    assert_equal "Lots to say for myself", JSON.parse(last_response.body)["details"]["description"]
   end
 
   should "return 404 if specific tag not found" do

--- a/test/integration/tag_request_test.rb
+++ b/test/integration/tag_request_test.rb
@@ -8,8 +8,8 @@ class TagRequestTest < GovUkContentApiTest
     ])
     get "/tags.json"
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["response"]["status"]
-    assert_equal 2, JSON.parse(last_response.body)['response']['results'].count
+    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_equal 2, JSON.parse(last_response.body)['results'].count
   end
 
   should "filter all tags by type" do
@@ -18,8 +18,8 @@ class TagRequestTest < GovUkContentApiTest
     ])
     get "/tags.json?type=Section"
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["response"]["status"]
-    assert_equal 1, JSON.parse(last_response.body)['response']['results'].count
+    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_equal 1, JSON.parse(last_response.body)['results'].count
   end
 
   should "load a specific tag" do
@@ -27,14 +27,14 @@ class TagRequestTest < GovUkContentApiTest
     Tag.expects(:where).with(tag_id: 'good-tag').returns([fake_tag])
     get '/tags/good-tag.json'
     assert last_response.ok?
-    assert_equal 'ok', JSON.parse(last_response.body)["response"]["status"]
-    assert_equal 'Lots to say for myself', JSON.parse(last_response.body)['response']['result']['fields']['description']
+    assert_equal 'ok', JSON.parse(last_response.body)["status"]
+    assert_equal 'Lots to say for myself', JSON.parse(last_response.body)['result']['fields']['description']
   end
 
   should "return 404 if specific tag not found" do
     Tag.expects(:where).with(tag_id: 'bad-tag').returns([])
     get '/tags/bad-tag.json'
     assert last_response.not_found?
-    assert_equal 'not found', JSON.parse(last_response.body)["response"]["status"]
+    assert_equal 'not found', JSON.parse(last_response.body)["status"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,8 +24,15 @@ DatabaseCleaner.strategy = :truncation
 # initial clean
 DatabaseCleaner.clean
 
+module ResponseTestMethods
+  def assert_status_field(expected, response)
+    assert_equal expected, JSON.parse(response.body)["_response_info"]["status"]
+  end
+end
+
 class GovUkContentApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
+  include ResponseTestMethods
 
   def app
     Sinatra::Application

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -9,5 +9,5 @@ glue @artefact do
   attribute :name => :title
   attribute :tag_ids
   node(:related_artefact_ids){ @artefact.related_artefacts.map(&:slug) }
-  node(:fields) { partial("fields", object: @artefact) }
+  node(:details) { partial("fields", object: @artefact) }
 end

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -1,11 +1,13 @@
 object false
-node(:status) { "ok" }
-node :result do
-  {
-    id: @artefact.slug,
-    title: @artefact.name,
-    tag_ids: @artefact.tag_ids,
-    related_artefact_ids: @artefact.related_artefacts.map(&:slug),
-    fields: partial("fields", object: @artefact)
-  }
+
+node :_response_info do
+  { status: "ok" }
+end
+
+glue @artefact do
+  attribute :slug => :id
+  attribute :name => :title
+  attribute :tag_ids
+  node(:related_artefact_ids){ @artefact.related_artefacts.map(&:slug) }
+  node(:fields) { partial("fields", object: @artefact) }
 end

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -1,18 +1,11 @@
 object false
-node :response do
-  basic = {
-    status: 'ok',
-    total: 1,
-    result: {
-      id: @artefact.slug,
-      title: @artefact.name,
-      tag_ids: @artefact.tag_ids,
-      related_artefact_ids: @artefact.related_artefacts.map(&:slug),
-      fields: {}
-    }
+node(:status) { "ok" }
+node :result do
+  {
+    id: @artefact.slug,
+    title: @artefact.name,
+    tag_ids: @artefact.tag_ids,
+    related_artefact_ids: @artefact.related_artefacts.map(&:slug),
+    fields: partial("fields", object: @artefact)
   }
-
-  basic[:result][:fields] = partial("fields", :object => @artefact)
-
-  basic
 end

--- a/views/gone.rabl
+++ b/views/gone.rabl
@@ -2,6 +2,6 @@ object false
 node :_response_info do
   {
     status: "gone",
-    status_message: "This item is no longer available" 
+    status_message: "This item is no longer available"
   }
 end

--- a/views/gone.rabl
+++ b/views/gone.rabl
@@ -1,8 +1,3 @@
 object false
-node :response do
-  {
-    status: 'gone',
-    status_message: 'This item is no longer available'
-  }
-end
-
+node(:status) { "gone" }
+node(:status_message) { "This item is no longer available" }

--- a/views/gone.rabl
+++ b/views/gone.rabl
@@ -1,3 +1,7 @@
 object false
-node(:status) { "gone" }
-node(:status_message) { "This item is no longer available" }
+node :_response_info do
+  {
+    status: "gone",
+    status_message: "This item is no longer available" 
+  }
+end

--- a/views/not_found.rabl
+++ b/views/not_found.rabl
@@ -1,7 +1,2 @@
 object false
-node :response do
-  {
-    status: 'not found'
-  }
-end
-
+node(:status) { "not found" }

--- a/views/not_found.rabl
+++ b/views/not_found.rabl
@@ -1,2 +1,4 @@
 object false
-node(:status) { "not found" }
+node :_response_info do
+  { status: "not found" }
+end

--- a/views/search.rabl
+++ b/views/search.rabl
@@ -11,7 +11,7 @@ node(:results) do
     {
       id: r.link,
       title: r.title,
-      fields: {
+      details: {
         description: r.description,
         additional_links: (r.additional_links || []).map { |al|
           {

--- a/views/search.rabl
+++ b/views/search.rabl
@@ -1,28 +1,25 @@
 object false
-node :response do
-  {
-    status: 'ok',
-    description: "Search for your query",
-    total: @results.count,
-    startIndex: 1,
-    pageSize: @results.count,
-    currentPage: 1,
-    pages: 1,
-    results: @results.map { |r|
-      {
-        id: r.link,
-        title: r.title,
-        fields: {
-          description: r.description,
-          additional_links: (r.additional_links || []).map { |al|
-            {
-              title: al.title,
-              url: al.link
-            }
+node(:status) { 'ok' }
+node(:total) { @results.count }
+node(:startIndex) { 1 }
+node(:pageSize) { @results.count }
+node(:currentPage) { 1 }
+node(:pages) { 1 }
+
+node(:results) do
+  @results.map { |r|
+    {
+      id: r.link,
+      title: r.title,
+      fields: {
+        description: r.description,
+        additional_links: (r.additional_links || []).map { |al|
+          {
+            title: al.title,
+            url: al.link
           }
         }
       }
     }
   }
 end
-

--- a/views/search.rabl
+++ b/views/search.rabl
@@ -1,5 +1,9 @@
 object false
-node(:status) { 'ok' }
+
+node :_response_info do
+  { status: "ok" }
+end
+
 node(:total) { @results.count }
 node(:startIndex) { 1 }
 node(:pageSize) { @results.count }

--- a/views/tag.rabl
+++ b/views/tag.rabl
@@ -1,20 +1,18 @@
 object false
-node(:status) { "ok" }
-node(:description) { "Items with tag" }
-node(:total) { "tbd" }
-node(:startIndex) { 1 }
-node(:pageSize) { "tbd" }
-node(:currentPage) { 1 }
-node(:pages) { 1 }
+object false
 
-node :result do
-  {
-    id: @tag.tag_id,
-    title: @tag.title,
-    fields: {
+node :_response_info do
+  { status: "ok" }
+end
+
+glue @tag do
+  attribute :tag_id => :id
+  attribute :title
+  node :fields do
+    {
       type: @tag.tag_type,
       description: @tag.description,
       parent: 'tbd' #@tag.parent_id
     }
-  }
+  end
 end

--- a/views/tag.rabl
+++ b/views/tag.rabl
@@ -1,22 +1,20 @@
 object false
-node :response do
+node(:status) { "ok" }
+node(:description) { "Items with tag" }
+node(:total) { "tbd" }
+node(:startIndex) { 1 }
+node(:pageSize) { "tbd" }
+node(:currentPage) { 1 }
+node(:pages) { 1 }
+
+node :result do
   {
-    status: 'ok',
-    description: "Items with tag",
-    total: 'tbd', #@tags.count,
-    startIndex: 1,
-    pageSize: 'tbd', #@tags.count,
-    currentPage: 1,
-    pages: 1,
-    result: {
-      id: @tag.tag_id,
-      title: @tag.title,
-      fields: {
-        type: @tag.tag_type,
-        description: @tag.description,
-        parent: 'tbd' #@tag.parent_id
-      }
+    id: @tag.tag_id,
+    title: @tag.title,
+    fields: {
+      type: @tag.tag_type,
+      description: @tag.description,
+      parent: 'tbd' #@tag.parent_id
     }
   }
 end
-

--- a/views/tag.rabl
+++ b/views/tag.rabl
@@ -1,5 +1,4 @@
 object false
-object false
 
 node :_response_info do
   { status: "ok" }

--- a/views/tag.rabl
+++ b/views/tag.rabl
@@ -8,7 +8,7 @@ end
 glue @tag do
   attribute :tag_id => :id
   attribute :title
-  node :fields do
+  node :details do
     {
       type: @tag.tag_type,
       description: @tag.description,

--- a/views/tags.rabl
+++ b/views/tags.rabl
@@ -1,5 +1,9 @@
 object false
-node(:status) { "ok" }
+
+node :_response_info do
+  { status: "ok" }
+end
+
 node(:description) { "Tags!" }
 node(:total) { @tags.count }
 node(:startIndex) { 1 }

--- a/views/tags.rabl
+++ b/views/tags.rabl
@@ -1,14 +1,13 @@
 object false
-node :response do
-  {
-    status: 'ok',
-    description: "Tags!",
-    total: @tags.count,
-    startIndex: 1,
-    pageSize: @tags.count,
-    currentPage: 1,
-    pages: 1,
-    results: @tags.map { |r|
+node(:status) { "ok" }
+node(:description) { "Tags!" }
+node(:total) { @tags.count }
+node(:startIndex) { 1 }
+node(:pageSize) { @tags.count }
+node(:currentPage) { 1 }
+node(:pages) { 1 }
+node(:results) do
+    @tags.map { |r|
       {
         id: r.tag_id,
         title: r.title,
@@ -19,6 +18,4 @@ node :response do
         }
       }
     }
-  }
 end
-

--- a/views/tags.rabl
+++ b/views/tags.rabl
@@ -15,7 +15,7 @@ node(:results) do
       {
         id: r.tag_id,
         title: r.title,
-        fields: {
+        details: {
           type: r.tag_type,
           description: 'tbd', #r.description,
           parent: 'tbd' #r.parent_id

--- a/views/unavailable.rabl
+++ b/views/unavailable.rabl
@@ -1,8 +1,5 @@
 object false
-node :response do
-  {
-    status: 'unavailable',
-    status_message: 'a necessary backend process was unavailable. please try again soon.'
-  }
-end
-
+node(:status) { "unavailable" }
+node(:status_message) {
+  "a necessary backend process was unavailable. Please try again soon."
+}

--- a/views/unavailable.rabl
+++ b/views/unavailable.rabl
@@ -1,5 +1,7 @@
 object false
-node(:status) { "unavailable" }
-node(:status_message) {
-  "a necessary backend process was unavailable. Please try again soon."
-}
+node :_response_info do
+  {
+    status: "unavailable",
+    status_message: "A necessary backend process was unavailable. Please try again soon."
+  }
+end

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -16,16 +16,16 @@ node(:results) do
     basic = {
       id: r.slug,
       title: r.name,
-      fields: {
+      details: {
         tags: r.tag_ids,
         format: r.kind,
       }
     }
 
     if r.edition and r.edition.is_a?(AnswerEdition)
-      basic[:fields][:overview] = r.edition.overview
-      basic[:fields][:body] = format_content(r.edition.body)
-      basic[:fields][:alternative_title] = r.edition.alternative_title
+      basic[:details][:overview] = r.edition.overview
+      basic[:details][:body] = format_content(r.edition.body)
+      basic[:details][:alternative_title] = r.edition.alternative_title
     end
 
     basic

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -1,30 +1,29 @@
 object false
-node :response do
-  {
-    status: 'ok',
-    description: "Search for your query",
-    total: @results.count,
-    startIndex: 1,
-    pageSize: @results.count,
-    currentPage: 1,
-    pages: 1,
-    results: @results.map { |r|
-      basic = {
-        id: r.slug,
-        title: r.name,
-        fields: {
-          tags: r.tag_ids,
-          format: r.kind,
-        }
+node(:status) { "ok" }
+node(:description) { "Search for your query" }
+node(:total) { @results.count }
+node(:startIndex) { 1 }
+node(:pageSize) { @results.count }
+node(:currentPage) { 1 }
+node(:pages) { 1 }
+
+node(:results) do
+  @results.map { |r|
+    basic = {
+      id: r.slug,
+      title: r.name,
+      fields: {
+        tags: r.tag_ids,
+        format: r.kind,
       }
-
-      if r.edition and r.edition.is_a?(AnswerEdition)
-        basic[:fields][:overview] = r.edition.overview
-        basic[:fields][:body] = format_content(r.edition.body)
-        basic[:fields][:alternative_title] = r.edition.alternative_title
-      end
-
-      basic
     }
+
+    if r.edition and r.edition.is_a?(AnswerEdition)
+      basic[:fields][:overview] = r.edition.overview
+      basic[:fields][:body] = format_content(r.edition.body)
+      basic[:fields][:alternative_title] = r.edition.alternative_title
+    end
+
+    basic
   }
 end

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -1,5 +1,9 @@
 object false
-node(:status) { "ok" }
+
+node :_response_info do
+  { status: "ok" }
+end
+
 node(:description) { "Search for your query" }
 node(:total) { @results.count }
 node(:startIndex) { 1 }


### PR DESCRIPTION
Rearrange the format of the API responses to avoid pain and suffering later on.

Views for singular resources now show the resource as the top-level response, with a `_response_info` key for response metadata. We also now call `fields` `details` to distinguish them from core fields and to avoid an association with database fields.
