### PR TITLE
Set logging to STDOUT in development

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -19,14 +19,11 @@ end
 
 enable :dump_errors, :raise_errors
 
-if in_development
-  log = STDOUT
-  log.sync = true
-else
+unless in_development
   log = File.new("log/sinatra.log", "a")
+  STDOUT.reopen(log)
+  STDERR.reopen(log)
 end
-STDOUT.reopen(log)
-STDERR.reopen(log)
 
 require 'govuk_content_api'
 run Sinatra::Application


### PR DESCRIPTION
- This makes it consistent with the Rails apps.
- It means that CTRL+C to bowler actually kills the contentapi.
- It means you don't have to open a separate tab to tail the contentapi
- log -- you can see it with the output from the other apps.

Minor niggle: I think it might mean that STDERR is going to STDOUT.
