### PR TITLE
Full tags and related artefacts

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -9,9 +9,10 @@ require 'mongoid'
 require 'govspeak'
 require 'plek'
 require 'escaping_helper'
+require 'url_helpers'
 require_relative "config"
 
-helpers EscapingHelper
+helpers EscapingHelper, URLHelpers
 
 set :views, File.expand_path('views', File.dirname(__FILE__))
 

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -1,0 +1,8 @@
+require "cgi"
+
+module URLHelpers
+
+  def tag_url(tag)
+    "#{@base_url}/tags/#{CGI.escape(tag.tag_id)}.json"
+  end
+end

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -5,4 +5,8 @@ module URLHelpers
   def tag_url(tag)
     "#{@base_url}/tags/#{CGI.escape(tag.tag_id)}.json"
   end
+
+  def artefact_url(artefact)
+    "#{@base_url}/#{CGI.escape(artefact.slug)}.json"
+  end
 end

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -12,7 +12,7 @@ class FormatsRequestTest < GovUkContentApiTest
     assert_equal 'ok', parsed_response["_response_info"]["status"]
     assert parsed_response.has_key?('title')
     assert parsed_response.has_key?('id')
-    assert parsed_response.has_key?('tag_ids')
+    assert parsed_response.has_key?('tags')
     assert parsed_response.has_key?('format')
   end
 

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -7,7 +7,6 @@ end
 glue @artefact do
   attribute :slug => :id
   attribute :name => :title
-  node(:related_artefact_ids){ @artefact.related_artefacts.map(&:slug) }
   node(:details) { partial("fields", object: @artefact) }
   if @artefact.edition
     node(:format) { @artefact.edition.format }
@@ -17,5 +16,9 @@ glue @artefact do
     node(:id) { |tag| tag_url(tag) }
     attribute :tag_type => :type
     attribute :title
+  end
+  child :related_artefacts => :related_artefacts do
+    node(:id) { |a| artefact_url(a) }
+    attribute :name => :title
   end
 end

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -12,7 +12,8 @@ glue @artefact do
   if @artefact.edition
     node(:format) { @artefact.edition.format }
   end
-  child :tags do
+  # Explicit naming here gives us an empty list if there are no tags
+  child :tags => :tags do
     node(:id) { |tag| tag_url(tag) }
     attribute :tag_type => :type
     attribute :title

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -7,10 +7,14 @@ end
 glue @artefact do
   attribute :slug => :id
   attribute :name => :title
-  attribute :tag_ids
   node(:related_artefact_ids){ @artefact.related_artefacts.map(&:slug) }
   node(:details) { partial("fields", object: @artefact) }
   if @artefact.edition
     node(:format) { @artefact.edition.format }
+  end
+  child :tags do
+    node(:id) { |tag| tag_url(tag) }
+    attribute :tag_type => :type
+    attribute :title
   end
 end

--- a/views/tag.rabl
+++ b/views/tag.rabl
@@ -5,7 +5,7 @@ node :_response_info do
 end
 
 glue @tag do
-  node(:id) { "#{@base_url}/tags/#{escape(@tag.tag_id)}.json" }
+  node(:id) { tag_url(@tag) }
   attribute :title
   node :details do
     {

--- a/views/tags.rabl
+++ b/views/tags.rabl
@@ -13,7 +13,7 @@ node(:pages) { 1 }
 node(:results) do
     @tags.map { |r|
       {
-        id: "#{@base_url}/tags/#{escape(r.tag_id)}.json",
+        id: tag_url(r),
         title: r.title,
         details: {
           type: r.tag_type,


### PR DESCRIPTION
Convert an artefact’s tags and related items to display as cut-down, linked representations of their resources.
