### PR TITLE
Make related artefacts consistent with top level

### DIFF
--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -6,13 +6,6 @@ node(:format, :if => lambda { |artefact| artefact.edition }) do |artefact|
   artefact.edition.format
 end
 
-# Explicit naming here gives us an empty list if there are no tags
 child :tags => :tags do
   extends "_tag"
-end
-
-child :related_artefacts => :related_artefacts do
-  node(:id) { |a| artefact_url(a) }
-  node(:web_url) { |a| artefact_web_url(a) }
-  attribute :name => :title
 end

--- a/views/_full_artefact.rabl
+++ b/views/_full_artefact.rabl
@@ -1,0 +1,5 @@
+extends "_basic_artefact"
+
+child :related_artefacts => :related_artefacts do
+  extends "_basic_artefact"
+end

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -5,5 +5,5 @@ node :_response_info do
 end
 
 glue @artefact do
-  extends "_artefact", object: @artefact
+  extends "_full_artefact", object: @artefact
 end

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -13,6 +13,6 @@ node(:pages) { 1 }
 
 node(:results) do
   @results.map { |r|
-    partial "_artefact", object: r
+    partial "_full_artefact", object: r
   }
 end


### PR DESCRIPTION
In order to do this, we want to reuse the artefact partial.
Unfortunately, that means that related artefacts have related
artefacts have related artefacts… and we get a "stack level too deep" 
error. RABL doesn't allow passing of options, so we can't specify 
which variant we want in the top level template.

Therefore, we need two partials: one - "basic" - with most 
of the artefact data, and a second one - "full" - that 
contains that plus the related artefacts, rendered with 
the basic template (and therefore without related artefacts). 

To top it all off, we can then reuse the "basic" template in the
"full" template as a base.
