### PR TITLE
Local authorities can be queried through the API

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -66,9 +66,8 @@ get "/local_authorities.json" do
     end
   end
 
-  search_param = params[:snac_code] || params[:council]
-
   unless @local_authorities.nil? || @local_authorities.empty?
+    search_param = params[:snac_code] || params[:council]
     statsd.time("request.local_authorities.#{search_param}.render") do
       render :rabl, :local_authorities, format: "json"
     end

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -66,7 +66,7 @@ get "/local_authorities.json" do
     end
   end
 
-  unless @local_authorities.nil? || @local_authorities.empty?
+  if @local_authorities && @local_authorities.any?
     search_param = params[:snac_code] || params[:council]
     statsd.time("request.local_authorities.#{search_param}.render") do
       render :rabl, :local_authorities, format: "json"

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -64,15 +64,17 @@ get "/local_authorities.json" do
         @local_authorities = LocalAuthority.where(snac: /^#{snac_code}/i).to_a
       end
     end
-  end
-
-  if @local_authorities && @local_authorities.any?
-    search_param = params[:snac_code] || params[:council]
-    statsd.time("request.local_authorities.#{search_param}.render") do
-      render :rabl, :local_authorities, format: "json"
-    end
   else
     custom_404
+  end
+
+  if @local_authorities.nil? or @local_authorities.empty?
+    @local_authorities = []
+  end
+
+  search_param = params[:snac_code] || params[:council]
+  statsd.time("request.local_authorities.#{search_param}.render") do
+    render :rabl, :local_authorities, format: "json"
   end
 end
 

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -50,11 +50,11 @@ end
 get "/local_authorities.json" do
   content_type :json
 
-  if params[:council]
-    council = params[:council].to_s.gsub(/[^0-9a-z ]/i, '')
-    unless council.empty?
-      statsd.time("request.local_authorities.#{council}") do
-        @local_authorities = LocalAuthority.where(name: /^#{council}/i).to_a
+  if params[:name]
+    name = params[:name].to_s.gsub(/[^0-9a-z ]/i, '')
+    unless name.empty?
+      statsd.time("request.local_authorities.#{name}") do
+        @local_authorities = LocalAuthority.where(name: /^#{name}/i).to_a
       end
     end
   elsif params[:snac_code]

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -78,7 +78,7 @@ get "/local_authorities.json" do
   end
 end
 
-get "/local_authority/:snac_code.json" do
+get "/local_authorities/:snac_code.json" do
   content_type :json
 
   if params[:snac_code]

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -51,18 +51,14 @@ get "/local_authorities.json" do
   content_type :json
 
   if params[:name]
-    name = params[:name].to_s.gsub(/[^0-9a-z ]/i, '')
-    unless name.empty?
-      statsd.time("request.local_authorities.#{name}") do
-        @local_authorities = LocalAuthority.where(name: /^#{name}/i).to_a
-      end
+    name = Regexp.escape(params[:name])
+    statsd.time("request.local_authorities.#{name}") do
+      @local_authorities = LocalAuthority.where(name: /^#{name}/i).to_a
     end
   elsif params[:snac_code]
-    snac_code = params[:snac_code].to_s.gsub(/[^0-9a-z ]/i, '')
-    unless snac_code.empty?
-      statsd.time("request.local_authorities.#{snac_code}") do
-        @local_authorities = LocalAuthority.where(snac: /^#{snac_code}/i).to_a
-      end
+    snac_code = Regexp.escape(params[:snac_code])
+    statsd.time("request.local_authorities.#{snac_code}") do
+      @local_authorities = LocalAuthority.where(snac: /^#{snac_code}/i).to_a
     end
   else
     custom_404

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -52,15 +52,15 @@ get "/local_authorities.json" do
 
   if params[:council]
     council = params[:council].to_s.gsub(/[^0-9a-z ]/i, '')
-    statsd.time("request.local_authorities.#{council}") do
-      if not params[:council].to_s.include? "*"
+    unless council.empty?
+      statsd.time("request.local_authorities.#{council}") do
         @local_authorities = LocalAuthority.where(name: /^#{council}/i).to_a
       end
     end
   elsif params[:snac_code]
     snac_code = params[:snac_code].to_s.gsub(/[^0-9a-z ]/i, '')
-    statsd.time("request.local_authorities.#{snac_code}") do
-      if not params[:snac_code].to_s.include? "*"
+    unless snac_code.empty?
+      statsd.time("request.local_authorities.#{snac_code}") do
         @local_authorities = LocalAuthority.where(snac: /^#{snac_code}/i).to_a
       end
     end

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -68,7 +68,7 @@ get "/local_authorities.json" do
 
   search_param = params[:snac_code] || params[:council]
 
-  if not @local_authorities.nil? and not @local_authorities.empty?
+  unless @local_authorities.nil? || @local_authorities.empty?
     statsd.time("request.local_authorities.#{search_param}.render") do
       render :rabl, :local_authorities, format: "json"
     end
@@ -86,7 +86,7 @@ get "/local_authority/:snac_code.json" do
     end
   end
 
-  if not @local_authority.nil?
+  if @local_authority
     statsd.time("request.local_authority.#{params[:snac_code]}.render") do
       render :rabl, :local_authority, format: "json"
     end

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -72,7 +72,7 @@ get "/local_authorities.json" do
     @local_authorities = []
   end
 
-  search_param = params[:snac_code] || params[:council]
+  search_param = params[:snac_code] || params[:name]
   statsd.time("request.local_authorities.#{search_param}.render") do
     render :rabl, :local_authorities, format: "json"
   end

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -1,7 +1,6 @@
 require "cgi"
 
 module URLHelpers
-
   def tag_url(tag)
     "#{base_api_url}/tags/#{CGI.escape(tag.tag_id)}.json"
   end
@@ -40,5 +39,9 @@ module URLHelpers
     else
       @_base_web_search_url ||= Plek.current.find('search')
     end
+  end
+
+  def local_authority_url(authority)
+    "#{base_api_url}/local_authority/#{CGI.escape(authority.snac)}.json"
   end
 end

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -33,7 +33,7 @@ module URLHelpers
       Plek.current.find(artefact.rendering_app || artefact.owning_app)
     end
   end
-  
+
   def base_web_search_url
     if ["production", "test"].include?(ENV["RACK_ENV"])
       @_base_web_search_url ||= Plek.current.find('www')

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -42,6 +42,6 @@ module URLHelpers
   end
 
   def local_authority_url(authority)
-    "#{base_api_url}/local_authority/#{CGI.escape(authority.snac)}.json"
+    "#{base_api_url}/local_authorities/#{CGI.escape(authority.snac)}.json"
   end
 end

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -11,7 +11,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_status_field "not found", last_response
   end
 
-  should "return 404 if no council name is provided" do
+  should "return 404 if no council name or snac code is provided" do
     get "/local_authorities.json"
     assert last_response.not_found?
     assert_status_field "not found", last_response
@@ -23,10 +23,14 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_status_field "not found", last_response
   end
 
-  should "return 404 if LocalAuthority with the provided council name not found" do
+  should "return an empty result set if LocalAuthority with the provided council name not found" do
     get "/local_authorities.json?council=Somewhere%20over%20the%20rainbow"
-    assert last_response.not_found?
-    assert_status_field "not found", last_response
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal 0, parsed_response["total"]
+    assert_equal true, parsed_response["results"].empty?
   end
 
   should "return a JSON formatted LocalAuthority when querying with a known snac code" do
@@ -104,11 +108,21 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
 
   should "not allow regex searching of snac codes" do
     get "/local_authorities.json?snac_code=*"
-    assert last_response.not_found?
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal 0, parsed_response["total"]
+    assert_equal true, parsed_response["results"].empty?
   end
 
   should "not allow regex searching of council" do
     get "/local_authorities.json?council=*"
-    assert last_response.not_found?
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal 0, parsed_response["total"]
+    assert_equal true, parsed_response["results"].empty?
   end
 end

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -103,24 +103,12 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
   end
 
   should "not allow regex searching of snac codes" do
-    stub_result = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
-                   LocalAuthority.new(name: "Solihull Test Council", snac: "00CF")]
-    LocalAuthority.stubs(:where).with(snac: /^0*/i).returns(stub_result)
-
-    get "/local_authorities.json?snac_code=0*"
-    parsed_response = JSON.parse(last_response.body)
-
+    get "/local_authorities.json?snac_code=*"
     assert last_response.not_found?
   end
 
   should "not allow regex searching of council" do
-    stub_result = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
-                   LocalAuthority.new(name: "Solihull Test Council", snac: "00CF")]
-    LocalAuthority.stubs(:where).with(name: /^S*/i).returns(stub_result)
-
-    get "/local_authorities.json?council=S*"
-    parsed_response = JSON.parse(last_response.body)
-
+    get "/local_authorities.json?council=*"
     assert last_response.not_found?
   end
 end

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+
+class LocalAuthorityRequestTest < GovUkContentApiTest
+  def assert_status_field(expected, response)
+    assert_equal expected, JSON.parse(response.body)["_response_info"]["status"]
+  end
+
+  should "return 404 if no snac code is provided" do
+    get "/local_authority.json"
+    assert last_response.not_found?
+    assert_status_field "not found", last_response
+  end
+
+  should "return 404 if no council name is provided" do
+    get "/local_authorities.json"
+    assert last_response.not_found?
+    assert_status_field "not found", last_response
+  end
+
+  should "return 404 if LocalAuthority with the provided snac code not found" do
+    get "/local_authority/gobble_de_gook.json"
+    assert last_response.not_found?
+    assert_status_field "not found", last_response
+  end
+
+  should "return 404 if LocalAuthority with the provided council name not found" do
+    get "/local_authorities.json?council=Somewhere%20over%20the%20rainbow"
+    assert last_response.not_found?
+    assert_status_field "not found", last_response
+  end
+
+  should "return a JSON formatted LocalAuthority when querying with a known snac code" do
+    stub_authority = LocalAuthority.new(name: "Super Nova", snac: "supernova")
+    LocalAuthority.stubs(:find_by_snac).with("supernova").returns(stub_authority)
+
+    get "/local_authority/supernova.json"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal "Super Nova", parsed_response["name"]
+    assert_equal "supernova", parsed_response["snac_code"]
+  end
+
+  should "return a JSON formatted array of LocalAuthority objects when searching by council" do
+    stub_authority = LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT")
+    LocalAuthority.stubs(:where).with(name: /^Solihull Metro/i).returns(stub_authority)
+
+    get "/local_authorities.json?council=Solihull%20Metro"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal "Solihull Metropolitan Borough Council", parsed_response["results"][0]["name"]
+    assert_equal "00CT", parsed_response["results"][0]["snac_code"]
+  end
+
+  should "return a JSON formatted array of LocalAuthority objects when searching by snac code" do
+    stub_authority = LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT")
+    LocalAuthority.stubs(:where).with(snac: /^00C/i).returns(stub_authority)
+
+    get "/local_authorities.json?snac_code=00C"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal "Solihull Metropolitan Borough Council", parsed_response["results"][0]["name"]
+    assert_equal "00CT", parsed_response["results"][0]["snac_code"]
+  end
+
+  should "return a JSON formatted array of multiple LocalAuthority objects when searching by council" do
+    stub_results = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
+                    LocalAuthority.new(name: "Solihull Council", snac: "00VT")]
+    LocalAuthority.stubs(:where).with(name: /^Solihull/i).returns(stub_results)
+
+    get "/local_authorities.json?council=Solihull"
+    parsed_response = JSON.parse(last_response.body)
+
+    expected = [{"name"=>"Solihull Metropolitan Borough Council", "snac_code"=>"00CT"},
+                {"name"=>"Solihull Council", "snac_code"=>"00VT"}]
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal 2, parsed_response["total"]
+    assert_equal expected, parsed_response["results"]
+  end
+
+  should "return a JSON formatted array of multiple LocalAuthority objects when searching by snac code" do
+    stub_result = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
+                   LocalAuthority.new(name: "Solihull Test Council", snac: "00CF")]
+    LocalAuthority.stubs(:where).with(snac: /^00C/i).returns(stub_result)
+
+    get "/local_authorities.json?snac_code=00C"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert_status_field "ok", last_response
+    assert_equal 2, parsed_response["total"]
+    assert_equal "Solihull Metropolitan Borough Council", parsed_response["results"][0]["name"]
+    assert_equal "00CT", parsed_response["results"][0]["snac_code"]
+    assert_equal "Solihull Test Council", parsed_response["results"][1]["name"]
+    assert_equal "00CF", parsed_response["results"][1]["snac_code"]
+  end
+
+  should "not allow regex searching of snac codes" do
+    stub_result = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
+                   LocalAuthority.new(name: "Solihull Test Council", snac: "00CF")]
+    LocalAuthority.stubs(:where).with(snac: /^0*/i).returns(stub_result)
+
+    get "/local_authorities.json?snac_code=0*"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.not_found?
+  end
+
+  should "not allow regex searching of council" do
+    stub_result = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
+                   LocalAuthority.new(name: "Solihull Test Council", snac: "00CF")]
+    LocalAuthority.stubs(:where).with(name: /^S*/i).returns(stub_result)
+
+    get "/local_authorities.json?council=S*"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.not_found?
+  end
+end

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -116,7 +116,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal "00CF", parsed_response["results"][1]["snac_code"]
   end
 
-  should "not allow regex searching of snac codes" do
+  should "not allow glob searching of snac codes" do
     get "/local_authorities.json?snac_code=*"
     parsed_response = JSON.parse(last_response.body)
 
@@ -126,7 +126,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal true, parsed_response["results"].empty?
   end
 
-  should "not allow regex searching of council" do
+  should "not allow glob searching of council" do
     get "/local_authorities.json?council=*"
     parsed_response = JSON.parse(last_response.body)
 

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -49,7 +49,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
 
   should "return a JSON formatted array of LocalAuthority objects when searching by name" do
     stub_authority = LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT")
-    LocalAuthority.stubs(:where).with(name: /^Solihull Metro/i).returns(stub_authority)
+    LocalAuthority.stubs(:where).with(name: /^Solihull\ Metro/i).returns(stub_authority)
 
     get "/local_authorities.json?name=Solihull%20Metro"
     parsed_response = JSON.parse(last_response.body)
@@ -116,6 +116,8 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
   end
 
   should "not allow glob searching of snac codes" do
+    LocalAuthority.expects(:where).with(snac: /^\*/i).once
+
     get "/local_authorities.json?snac_code=*"
     parsed_response = JSON.parse(last_response.body)
 
@@ -126,6 +128,8 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
   end
 
   should "not allow glob searching of names" do
+    LocalAuthority.expects(:where).with(name: /^\*/i).once
+
     get "/local_authorities.json?name=*"
     parsed_response = JSON.parse(last_response.body)
 

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -3,10 +3,6 @@ require "test_helper"
 class LocalAuthorityRequestTest < GovUkContentApiTest
   include URLHelpers
 
-  def assert_status_field(expected, response)
-    assert_equal expected, JSON.parse(response.body)["_response_info"]["status"]
-  end
-
   should "return 404 if no snac code is provided" do
     get "/local_authorities/"
     assert last_response.not_found?

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -8,9 +8,8 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
   end
 
   should "return 404 if no snac code is provided" do
-    get "/local_authority.json"
+    get "/local_authorities/"
     assert last_response.not_found?
-    assert_status_field "not found", last_response
   end
 
   should "return 404 if no name or snac code is provided" do
@@ -20,7 +19,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
   end
 
   should "return 404 if LocalAuthority with the provided snac code not found" do
-    get "/local_authority/gobble_de_gook.json"
+    get "/local_authorities/gobble_de_gook.json"
     assert last_response.not_found?
     assert_status_field "not found", last_response
   end
@@ -39,7 +38,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     stub_authority = LocalAuthority.new(name: "Super Nova", snac: "supernova")
     LocalAuthority.stubs(:find_by_snac).with("supernova").returns(stub_authority)
 
-    get "/local_authority/supernova.json"
+    get "/local_authorities/supernova.json"
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
@@ -85,12 +84,12 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     expected = [{
                   "name" => "Solihull Metropolitan Borough Council",
                   "snac_code" => "00CT",
-                  "id" => "#{base_api_url}/local_authority/00CT.json"
+                  "id" => "#{base_api_url}/local_authorities/00CT.json"
                 },
                 {
                   "name" => "Solihull Council",
                   "snac_code" => "00VT",
-                  "id" => "#{base_api_url}/local_authority/00VT.json"
+                  "id" => "#{base_api_url}/local_authorities/00VT.json"
                 }]
 
     assert last_response.ok?
@@ -145,18 +144,18 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
 
     assert last_response.ok?
     assert_status_field "ok", last_response
-    assert_equal "#{base_api_url}/local_authority/00CT.json", parsed_response["results"][0]["id"]
+    assert_equal "#{base_api_url}/local_authorities/00CT.json", parsed_response["results"][0]["id"]
   end
 
   should "have a canonical ID for the provided response when directly accessing with a snac code" do
     stub_authority = LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT")
     LocalAuthority.stubs(:find_by_snac).with("00CT").returns(stub_authority)
 
-    get "/local_authority/00CT.json"
+    get "/local_authorities/00CT.json"
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
     assert_status_field "ok", last_response
-    assert_equal "#{base_api_url}/local_authority/00CT.json", parsed_response["id"]
+    assert_equal "#{base_api_url}/local_authorities/00CT.json", parsed_response["id"]
   end
 end

--- a/test/integration/local_authority_request_test.rb
+++ b/test/integration/local_authority_request_test.rb
@@ -13,7 +13,7 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_status_field "not found", last_response
   end
 
-  should "return 404 if no council name or snac code is provided" do
+  should "return 404 if no name or snac code is provided" do
     get "/local_authorities.json"
     assert last_response.not_found?
     assert_status_field "not found", last_response
@@ -25,8 +25,8 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_status_field "not found", last_response
   end
 
-  should "return an empty result set if LocalAuthority with the provided council name not found" do
-    get "/local_authorities.json?council=Somewhere%20over%20the%20rainbow"
+  should "return an empty result set if LocalAuthority with the provided name not found" do
+    get "/local_authorities.json?name=Somewhere%20over%20the%20rainbow"
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
@@ -48,11 +48,11 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal "supernova", parsed_response["snac_code"]
   end
 
-  should "return a JSON formatted array of LocalAuthority objects when searching by council" do
+  should "return a JSON formatted array of LocalAuthority objects when searching by name" do
     stub_authority = LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT")
     LocalAuthority.stubs(:where).with(name: /^Solihull Metro/i).returns(stub_authority)
 
-    get "/local_authorities.json?council=Solihull%20Metro"
+    get "/local_authorities.json?name=Solihull%20Metro"
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
@@ -74,12 +74,12 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal "00CT", parsed_response["results"][0]["snac_code"]
   end
 
-  should "return a JSON formatted array of multiple LocalAuthority objects when searching by council" do
+  should "return a JSON formatted array of multiple LocalAuthority objects when searching by name" do
     stub_results = [LocalAuthority.new(name: "Solihull Metropolitan Borough Council", snac: "00CT"),
                     LocalAuthority.new(name: "Solihull Council", snac: "00VT")]
     LocalAuthority.stubs(:where).with(name: /^Solihull/i).returns(stub_results)
 
-    get "/local_authorities.json?council=Solihull"
+    get "/local_authorities.json?name=Solihull"
     parsed_response = JSON.parse(last_response.body)
 
     expected = [{
@@ -126,8 +126,8 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal true, parsed_response["results"].empty?
   end
 
-  should "not allow glob searching of council" do
-    get "/local_authorities.json?council=*"
+  should "not allow glob searching of names" do
+    get "/local_authorities.json?name=*"
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?

--- a/views/_local_authority.rabl
+++ b/views/_local_authority.rabl
@@ -1,0 +1,2 @@
+attribute :name
+attribute :snac => :snac_code

--- a/views/_local_authority.rabl
+++ b/views/_local_authority.rabl
@@ -1,2 +1,4 @@
+node(:id) { |authority| local_authority_url(authority) }
 attribute :name
 attribute :snac => :snac_code
+

--- a/views/local_authorities.rabl
+++ b/views/local_authorities.rabl
@@ -1,0 +1,13 @@
+object false
+
+node :_response_info do
+  { status: "ok" }
+end
+
+node(:description) { "Local Authorities" }
+node(:total) { @local_authorities.count }
+node(:results) do
+  @local_authorities.map { |authority|
+    partial "_local_authority", object: authority
+  }
+end

--- a/views/local_authority.rabl
+++ b/views/local_authority.rabl
@@ -1,0 +1,9 @@
+object false
+
+node :_response_info do
+  { status: "ok" }
+end
+
+glue @local_authority do
+  extends "_local_authority", object: @local_authority
+end


### PR DESCRIPTION
LocalAuthority objects should be queryable with a specific (unique) and searchable in the event that a name match would suffice. This commit allows doing both.

The unique field for a LocalAuthority is the snac code, which is why there's a direct route in the form of /local_authority/snac_code.json. However it's also possible to do a partial search of a snac code using
the /local_authorities.json slug.

Similarly, it's possible to search for council names using the /local_authorities.json slug. This can be done both partially or directly.
