### PR TITLE
API URLs generated in context of the URL they were requested from

### DIFF
--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -11,7 +11,7 @@ module URLHelpers
   end
 
   def with_tag_web_url(tag)
-    url("/browse/#{tag.tag_id}")
+    "#{base_web_search_url}/browse/#{tag.tag_id}"
   end
 
   def artefact_url(artefact)
@@ -19,7 +19,7 @@ module URLHelpers
   end
 
   def artefact_web_url(artefact)
-    url("/#{artefact.slug}")
+    "#{base_web_url(artefact)}/#{artefact.slug}"
   end
 
   def base_web_url(artefact)

--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -51,7 +51,7 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     assert_status_field "ok", last_response
     assert_equal "http://example.org/#{stub_artefact.slug}.json", parsed_response["id"]
-    assert_equal "http://example.org/#{stub_artefact.slug}", parsed_response["web_url"]
+    assert_equal "http://www.test.gov.uk/#{stub_artefact.slug}", parsed_response["web_url"]
     assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
     assert_equal "1234", parsed_response["details"]["need_id"]
     # Temporarily included for legacy GA support. Will be replaced with "proposition" Tags
@@ -113,7 +113,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal artefact.name, related_info["title"]
       artefact_path = "/#{CGI.escape(artefact.slug)}.json"
       assert_equal artefact_path, URI.parse(related_info["id"]).path
-      assert_equal "http://example.org/#{artefact.slug}", related_info["web_url"]
+      assert_equal "http://www.test.gov.uk/#{artefact.slug}", related_info["web_url"]
     end
   end
 
@@ -185,7 +185,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal tag_path, URI.parse(tag_info["id"]).path
       assert_equal nil, tag_info["web_url"]
       assert_equal "section", tag_info["details"]["type"]
-      assert_equal "http://example.org/browse/#{section[0]}", tag_info["content_with_tag"]["web_url"]
+      assert_equal "http://www.test.gov.uk/browse/#{section[0]}", tag_info["content_with_tag"]["web_url"]
     end
   end
 

--- a/test/integration/tag_request_test.rb
+++ b/test/integration/tag_request_test.rb
@@ -28,7 +28,7 @@ class TagRequestTest < GovUkContentApiTest
       tag = FactoryGirl.create(:tag, tag_id: 'crime')
       get "/tags.json"
       expected_id = "http://example.org/tags/crime.json"
-      expected_url = "http://example.org/browse/crime"
+      expected_url = "http://www.test.gov.uk/browse/crime"
       assert_equal expected_id, JSON.parse(last_response.body)['results'][0]['id']
       assert_equal nil, JSON.parse(last_response.body)['results'][0]['web_url']
       assert_equal expected_url, JSON.parse(last_response.body)['results'][0]["content_with_tag"]["web_url"]
@@ -46,7 +46,7 @@ class TagRequestTest < GovUkContentApiTest
       assert_equal "Lots to say for myself", response["details"]["description"]
       assert_equal "http://example.org/tags/good-tag.json", response["id"]
       assert_equal nil, response["web_url"]
-      assert_equal "http://example.org/browse/good-tag", response["content_with_tag"]["web_url"]
+      assert_equal "http://www.test.gov.uk/browse/good-tag", response["content_with_tag"]["web_url"]
     end
 
     should "return 404 if specific tag not found" do
@@ -107,7 +107,7 @@ class TagRequestTest < GovUkContentApiTest
           },
           "content_with_tag" => {
             "id" => "http://example.org/with_tag.json?tag=crime-and-prison",
-            "web_url" => "http://example.org/browse/crime-and-prison"
+            "web_url" => "http://www.test.gov.uk/browse/crime-and-prison"
           },
           "parent" => nil,
           "title" => @parent.title


### PR DESCRIPTION
- Uses Sinatra's built in url helper so we don't need to manually munge the URL together.
- SSL tested.
- /api needs to be double checked in production
