### PR TITLE
Additional continuation fields for LicenceEditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '1.7.2'
+  gem 'govuk_content_models', '1.8.0'
 end
 
-gem 'govspeak', '0.8.15'
+gem 'govspeak', '1.0.1'
 gem 'factory_girl', '3.6.1'
 gem 'database_cleaner', '0.7.2'
 gem 'plek', '0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    gds-api-adapters (1.7.0)
+    gds-api-adapters (1.8.0)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -60,19 +60,19 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    govspeak (0.8.15)
+    govspeak (1.0.1)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-    govuk_content_models (1.7.2)
+      sanitize (= 2.0.3)
+    govuk_content_models (1.8.0)
       bson_ext
       differ
       gds-api-adapters
-      gds-sso (>= 0.7, < 2.0)
-      govspeak (>= 0.8.15, < 2.0.0)
+      gds-sso (>= 0.7, < 3.0)
+      govspeak (>= 1.0.1, < 2.0.0)
       mongoid (~> 2.4.10)
       omniauth-oauth2 (~> 1.0)
       plek (>= 0.1.22, < 0.4)
-      sanitize (= 2.0.3)
       state_machine
     hashie (1.2.0)
     hike (1.2.1)
@@ -84,7 +84,7 @@ GEM
     jwt (0.1.5)
       multi_json (>= 1.0)
     kgio (2.7.4)
-    kramdown (0.13.7)
+    kramdown (0.13.8)
     lrucache (0.1.3)
       PriorityQueue (~> 0.1.2)
     mail (2.4.4)
@@ -208,8 +208,8 @@ DEPENDENCIES
   database_cleaner (= 0.7.2)
   delsolr!
   factory_girl (= 3.6.1)
-  govspeak (= 0.8.15)
-  govuk_content_models (= 1.7.2)
+  govspeak (= 1.0.1)
+  govuk_content_models (= 1.8.0)
   minitest (= 3.3.0)
   mocha (= 0.12.3)
   plek (= 0.3.0)

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -128,7 +128,8 @@ class FormatsRequestTest < GovUkContentApiTest
   should "licence_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman-licence', owning_app: 'publisher', sections: [@tag1.tag_id])
     licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Batman licence',
-                                licence_overview: 'Not just anyone can be Batman', panopticon_id: artefact.id, state: 'published')
+                                licence_overview: 'Not just anyone can be Batman', panopticon_id: artefact.id, state: 'published',
+                                will_continue_on: 'The Batman', continuation_link: 'http://www.batman.com')
     get '/batman-licence.json'
     parsed_response = JSON.parse(last_response.body)
 
@@ -136,7 +137,7 @@ class FormatsRequestTest < GovUkContentApiTest
     _assert_base_response_info(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['alternative_title', 'licence_overview', 'licence_short_description', 'licence_identifier']
+    expected_fields = ['alternative_title', 'licence_overview', 'licence_short_description', 'licence_identifier', 'will_continue_on', 'continuation_link']
 
     _assert_has_expected_fields(fields, expected_fields)
     assert_equal "Not just anyone can be Batman", fields["licence_overview"]

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -2,7 +2,7 @@ node(:need_id) { |artefact| artefact.need_id }
 node(:business_proposition) { |artefact| artefact.business_proposition }
 
 [:format, :alternative_title, :overview, :more_information, :min_value, :max_value, 
-    :short_description, :introduction, :will_continue_on, :link, :alternate_methods, 
+    :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods, 
     :video_summary, :video_url, :licence_identifier, :licence_short_description, :licence_overview,
     :lgsl_code, :lgil_override, :minutes_to_complete, :expectation_ids, :place_type].each do |field|
   node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact| 


### PR DESCRIPTION
Adds additional fields for LicenceEditions, balances work done in publisher here: https://github.com/alphagov/publisher/pull/28 
