### PR TITLE
Parts have web_urls and slugs, not an id

### DIFF
--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -202,7 +202,8 @@ class ArtefactRequestTest < GovUkContentApiTest
     assert last_response.ok?
 
     expected_first_part = {
-      "id" => "http://www.test.gov.uk/published-artefact/part-one",
+      "web_url" => "http://www.test.gov.uk/published-artefact/part-one",
+      "slug" => "part-one",
       "order" => 1,
       "title" => "Part One",
       "body" => "<h2>Header 2</h2>\n"

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -81,7 +81,8 @@ class FormatsRequestTest < GovUkContentApiTest
     refute fields.has_key?('body')
     assert_equal "Some Part Title!", fields['parts'][0]['title']
     assert_equal "<p>This is some <strong>version</strong> text.</p>\n", fields['parts'][0]['body']
-    assert_equal "http://www.test.gov.uk/batman/part-one", fields['parts'][0]['id']
+    assert_equal "http://www.test.gov.uk/batman/part-one", fields['parts'][0]['web_url']
+    assert_equal "part-one", fields['parts'][0]['slug']
   end
 
   should "programme_edition" do
@@ -102,7 +103,8 @@ class FormatsRequestTest < GovUkContentApiTest
     _assert_has_expected_fields(fields, expected_fields)
     refute fields.has_key?('body')
     assert_equal "Overview", fields['parts'][0]['title']
-    assert_equal "http://www.test.gov.uk/batman/overview", fields['parts'][0]['id']
+    assert_equal "http://www.test.gov.uk/batman/overview", fields['parts'][0]['web_url']
+    assert_equal "overview", fields['parts'][0]['slug']
   end
 
   should "video_edition" do

--- a/views/_parts.rabl
+++ b/views/_parts.rabl
@@ -2,7 +2,8 @@ node do |artefact|
   list_parts = []
   artefact.edition.parts.each do |p|
     part = {
-              id: artefact_part_web_url(artefact, p),
+              web_url: artefact_part_web_url(artefact, p),
+              slug: p.slug,
               order: p.order,
               title: p.title,
               body: format_content(p.body)


### PR DESCRIPTION
This pull request drops slugs, adds an id which is labelled web_url:
https://github.com/alphagov/govuk_content_api/pull/14

This feels inconsistent - everywhere else id is an API URL, and web_urls are web URLs.

Slugs are retained/reinstated to act as a pseudo-id within the scope of the artefact. They also might make implementing frontend app code slightly easier.
