### PR TITLE
Add kind field to artefact at top-level

### DIFF
--- a/test/integration/artefact_request_test.rb
+++ b/test/integration/artefact_request_test.rb
@@ -212,4 +212,15 @@ class ArtefactRequestTest < GovUkContentApiTest
     }
     assert_equal expected_first_part, parsed_response["details"]["parts"][0]
   end
+
+  it "should set the kind field at the top-level from the artefact" do
+    stub_artefact = Artefact.new(slug: 'smart-answer', owning_app: 'smart-answers', kind: 'smart-answer')
+    Artefact.stubs(:where).with(slug: 'smart-answer').returns([stub_artefact])
+
+    get '/smart-answer.json'
+
+    assert last_response.ok?
+    response = JSON.parse(last_response.body)
+    assert_equal 'smart-answer', response["kind"]
+  end
 end

--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -1,4 +1,5 @@
 node(:id) { |artefact| artefact_url(artefact) }
 node(:web_url) { |artefact| artefact_web_url(artefact) }
 attribute :name => :title
+attribute :kind
 node(:details) { |artefact| partial("fields", object: artefact) }


### PR DESCRIPTION
This deprecates the format field in the details group, which will be removed in time.  The format is a publisher specific field (actually derived from the Edition class name), whereas the kind field applies to all artefacts.
