### PR TITLE
Include licence details from Licensify in API responses for LicenceEditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '2.3.0'
+  gem 'gds-api-adapters', '2.4.0'
 end
 
 gem 'govspeak', '1.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,12 @@ else
   gem 'govuk_content_models', '1.8.0'
 end
 
+if ENV['API_DEV']
+  gem 'gds-api-adapters', :path => '../gds-api-adapters'
+else
+  gem 'gds-api-adapters', '2.3.0'
+end
+
 gem 'govspeak', '1.0.1'
 gem 'plek', '0.3.0'
 gem 'router-client', '3.1.0', :require => false
@@ -27,6 +33,7 @@ group :development, :test do
   gem 'simplecov-rcov', '0.2.3'
   gem 'minitest', '3.4.0'
   gem 'ci_reporter', '1.7.0'
+  gem 'webmock', '~> 1.8', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,13 +37,15 @@ GEM
     activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    addressable (2.3.2)
     arel (3.0.2)
     bson (1.6.4)
     bson_ext (1.6.4)
       bson (~> 1.6.4)
-    builder (3.0.0)
+    builder (3.0.3)
     ci_reporter (1.7.0)
       builder (>= 2.1.2)
+    crack (0.3.1)
     database_cleaner (0.7.2)
     differ (0.1.2)
     erubis (2.7.0)
@@ -51,7 +53,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    gds-api-adapters (1.8.0)
+    gds-api-adapters (2.3.0)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -192,6 +194,9 @@ GEM
       raindrops (~> 0.7)
     warden (1.2.1)
       rack (>= 1.0)
+    webmock (1.8.10)
+      addressable (>= 2.2.7)
+      crack (>= 0.1.7)
     yajl-ruby (1.1.0)
 
 PLATFORMS
@@ -202,6 +207,7 @@ DEPENDENCIES
   database_cleaner (= 0.7.2)
   delsolr!
   factory_girl (= 3.6.1)
+  gds-api-adapters (= 2.3.0)
   govspeak (= 1.0.1)
   govuk_content_models (= 1.8.0)
   minitest (= 3.4.0)
@@ -216,4 +222,5 @@ DEPENDENCIES
   sinatra (= 1.3.2)
   statsd-ruby (= 1.0.0)
   unicorn (~> 4.3.1)
+  webmock (~> 1.8)
   yajl-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    gds-api-adapters (2.3.0)
+    gds-api-adapters (2.4.0)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -207,7 +207,7 @@ DEPENDENCIES
   database_cleaner (= 0.7.2)
   delsolr!
   factory_girl (= 3.6.1)
-  gds-api-adapters (= 2.3.0)
+  gds-api-adapters (= 2.4.0)
   govspeak (= 1.0.1)
   govuk_content_models (= 1.8.0)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -212,7 +212,13 @@ get "/:id.json" do
     end
 
     if @artefact.edition and @artefact.edition.format == 'Licence'
-      @artefact.licence = licence_application_api.details_for_licence(@artefact.edition.licence_identifier)
+      begin
+        statsd.time("request.id.#{params[:id]}.licence") do
+          @artefact.licence = licence_application_api.details_for_licence(@artefact.edition.licence_identifier, params[:snac])
+        end
+      rescue GdsApi::TimedOutException, GdsApi::HTTPErrorResponse
+        @artefact.licence = nil
+      end
     end
 
     unless @artefact.edition

--- a/test/integration/formats_request_test.rb
+++ b/test/integration/formats_request_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
+require "gds_api/test_helpers/licence_application"
 
 class FormatsRequestTest < GovUkContentApiTest
+  include GdsApi::TestHelpers::LicenceApplication
 
   def setup
     super
@@ -131,7 +133,9 @@ class FormatsRequestTest < GovUkContentApiTest
     artefact = FactoryGirl.create(:artefact, slug: 'batman-licence', owning_app: 'publisher', sections: [@tag1.tag_id])
     licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Batman licence',
                                 licence_overview: 'Not just anyone can be Batman', panopticon_id: artefact.id, state: 'published',
-                                will_continue_on: 'The Batman', continuation_link: 'http://www.batman.com')
+                                will_continue_on: 'The Batman', continuation_link: 'http://www.batman.com', licence_identifier: "123-4-5")
+    licence_exists('123-4-5', { })
+
     get '/batman-licence.json'
     parsed_response = JSON.parse(last_response.body)
 

--- a/test/integration/licence_request_test.rb
+++ b/test/integration/licence_request_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require "gds_api/test_helpers/licence_application"
+
+class LicenceRequestTest < GovUkContentApiTest
+  include GdsApi::TestHelpers::LicenceApplication
+
+  it "should return full licence details for an edition with a licence identifier" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: '123-2-1', licence_overview: "")
+
+    authorities = [{
+      "authorityName" => "Authority",
+      "authorityInteractions" => {
+        "apply" => [{
+          "url" => "http://gov.uk/apply",
+          "usesLicensify" => true,
+          "description" => "Apply for all the things",
+          "payment" => "none",
+          "introductionText" => "Licence all the things"
+        }],
+        "renew" => [{
+          "url" => "http://gov.uk/renew",
+          "usesLicensify" => true,
+          "description" => "Renew all the things",
+          "payment" => "none",
+          "introductionText" => "Licence all the things"
+        }]
+      }
+    }]
+    licence_exists('123-2-1', {"isLocationSpecific" => false, "geographicalAvailability" => ["England","Wales"], "issuingAuthorities" => authorities})
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert parsed_response["details"]["licence"].present?
+
+    assert_equal false, parsed_response["details"]["licence"]["location_specific"]
+    assert_equal ["England","Wales"], parsed_response["details"]["licence"]["availability"]
+
+    assert_equal ['Authority'], parsed_response["details"]["licence"]["authorities"].map {|r| r['name']}
+    assert_equal ['Apply for all the things', 'Renew all the things'], parsed_response["details"]["licence"]["authorities"].first["actions"].map {|k,v| v.first["description"] }
+  end
+
+end

--- a/test/integration/licence_request_test.rb
+++ b/test/integration/licence_request_test.rb
@@ -5,8 +5,8 @@ class LicenceRequestTest < GovUkContentApiTest
   include GdsApi::TestHelpers::LicenceApplication
 
   it "should return full licence details for an edition with a licence identifier" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: '123-2-1', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: '123-2-1')
 
     authorities = [{
       "authorityName" => "Authority",
@@ -30,7 +30,7 @@ class LicenceRequestTest < GovUkContentApiTest
     licence_exists('123-2-1', {"isLocationSpecific" => false, "geographicalAvailability" => ["England","Wales"], "issuingAuthorities" => authorities})
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json'
     parsed_response = JSON.parse(last_response.body)
@@ -46,8 +46,8 @@ class LicenceRequestTest < GovUkContentApiTest
   end
 
   it "should return location-specific licence details for an edition with a licence identifier and snac code" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: '123-2-1', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: '123-2-1')
 
     authorities = [{
       "authorityName" => "South Ribble Borough Council",
@@ -64,7 +64,7 @@ class LicenceRequestTest < GovUkContentApiTest
     licence_exists('123-2-1/41UH', {"isLocationSpecific" => true, "geographicalAvailability" => ["England","Wales"], "issuingAuthorities" => authorities})
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json?snac=41UH'
 
@@ -80,11 +80,11 @@ class LicenceRequestTest < GovUkContentApiTest
   end
 
 it "should not query the licence api if no licence identifier is present" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: nil, licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: nil)
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json'
     parsed_response = JSON.parse(last_response.body)
@@ -94,13 +94,13 @@ it "should not query the licence api if no licence identifier is present" do
   end
 
   it "should not return any licence details if the licence does not exist in the licence application tool" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
     licence_does_not_exist('blaaargh')
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json'
     parsed_response = JSON.parse(last_response.body)
@@ -110,13 +110,13 @@ it "should not query the licence api if no licence identifier is present" do
   end
 
   it "should not return any licence details if the licence does not exist in the licence application tool when provided with a snac code" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
     licence_does_not_exist('blaaargh/43UG')
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json?snac=43UG'
     parsed_response = JSON.parse(last_response.body)
@@ -126,13 +126,13 @@ it "should not query the licence api if no licence identifier is present" do
   end
 
   it "should not blow the stack if the api request times out" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
     licence_times_out('blaaargh/43UG')
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json?snac=43UG'
     parsed_response = JSON.parse(last_response.body)
@@ -142,13 +142,13 @@ it "should not query the licence api if no licence identifier is present" do
   end
 
   it "should not blow the stack if the api request returns an error" do
-    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
-    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
     licence_returns_error('blaaargh')
 
     Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
-    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+    Edition.stubs(:where).with(panopticon_id: stub_artefact.id, state: 'published').returns([stub_licence])
 
     get '/licence-artefact.json'
     parsed_response = JSON.parse(last_response.body)

--- a/test/integration/licence_request_test.rb
+++ b/test/integration/licence_request_test.rb
@@ -45,4 +45,102 @@ class LicenceRequestTest < GovUkContentApiTest
     assert_equal ['Apply for all the things', 'Renew all the things'], parsed_response["details"]["licence"]["authorities"].first["actions"].map {|k,v| v.first["description"] }
   end
 
+  it "should return location-specific licence details for an edition with a licence identifier and snac code" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: '123-2-1', licence_overview: "")
+
+    authorities = [{
+      "authorityName" => "South Ribble Borough Council",
+      "authorityInteractions" => {
+        "apply" => [{
+          "url" => "http://www.gov.uk/licence-artefact/south-ribble/apply=1",
+          "usesLicensify" => true,
+          "description" => "Apply for one thing",
+          "payment" => "none",
+          "introductionText" => "Licence one thing"
+        }]
+      }
+    }]
+    licence_exists('123-2-1/41UH', {"isLocationSpecific" => true, "geographicalAvailability" => ["England","Wales"], "issuingAuthorities" => authorities})
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json?snac=41UH'
+
+    parsed_response = JSON.parse(last_response.body)
+    authority = parsed_response["details"]["licence"]["authorities"].first
+
+    assert last_response.ok?
+
+    assert_equal "South Ribble Borough Council", authority["name"]
+    assert_equal 1, authority["actions"]["apply"].size
+    assert_equal "Apply for one thing", authority["actions"]["apply"].first["description"]
+    assert_equal "http://www.gov.uk/licence-artefact/south-ribble/apply=1", authority["actions"]["apply"].first["url"]
+  end
+
+  it "should not return any licence details if the licence does not exist in the licence application tool" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+
+    licence_does_not_exist('blaaargh')
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert ! parsed_response["details"]["licence"].present?
+  end
+
+  it "should not return any licence details if the licence does not exist in the licence application tool when provided with a snac code" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+
+    licence_does_not_exist('blaaargh/43UG')
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json?snac=43UG'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert ! parsed_response["details"][" licence"].present?
+  end
+
+  it "should not blow the stack if the api request times out" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+
+    licence_times_out('blaaargh/43UG')
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json?snac=43UG'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert ! parsed_response["details"][" licence"].present?
+  end
+
+  it "should not blow the stack if the api request returns an error" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")
+
+    licence_returns_error('blaaargh')
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert ! parsed_response["details"][" licence"].present?
+  end
+
 end

--- a/test/integration/licence_request_test.rb
+++ b/test/integration/licence_request_test.rb
@@ -79,6 +79,20 @@ class LicenceRequestTest < GovUkContentApiTest
     assert_equal "http://www.gov.uk/licence-artefact/south-ribble/apply=1", authority["actions"]["apply"].first["url"]
   end
 
+it "should not query the licence api if no licence identifier is present" do
+    stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
+    stub_licence = LicenceEdition.new(licence_identifier: nil, licence_overview: "")
+
+    Artefact.stubs(:where).with(slug: 'licence-artefact').returns([stub_artefact])
+    Edition.stubs(:where).with(slug: 'licence-artefact', state: 'published').returns([stub_licence])
+
+    get '/licence-artefact.json'
+    parsed_response = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert ! parsed_response["details"]["licence"].present?
+  end
+
   it "should not return any licence details if the licence does not exist in the licence application tool" do
     stub_artefact = Artefact.new(slug: 'licence-artefact', owning_app: 'publisher', business_proposition: true, need_id: 1234)
     stub_licence = LicenceEdition.new(licence_identifier: 'blaaargh', licence_overview: "")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,5 +46,6 @@ class GovUkContentApiTest < MiniTest::Spec
 
   def teardown
     DatabaseCleaner.clean
+    WebMock.reset!
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,12 +16,15 @@ require 'rack/test'
 require 'database_cleaner'
 require 'mocha'
 require 'factory_girl'
+require 'webmock/minitest'
 require 'govuk_content_api'
 require 'govuk_content_models/test_helpers/factories'
 
 DatabaseCleaner.strategy = :truncation
 # initial clean
 DatabaseCleaner.clean
+
+WebMock.disable_net_connect!
 
 module ResponseTestMethods
   def assert_status_field(expected, response)

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -1,19 +1,23 @@
 node(:need_id) { |artefact| artefact.need_id }
 node(:business_proposition) { |artefact| artefact.business_proposition }
 
-[:format, :alternative_title, :overview, :more_information, :min_value, :max_value, 
-    :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods, 
+[:format, :alternative_title, :overview, :more_information, :min_value, :max_value,
+    :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods,
     :video_summary, :video_url, :licence_identifier, :licence_short_description, :licence_overview,
     :lgsl_code, :lgil_override, :minutes_to_complete, :expectation_ids, :place_type].each do |field|
-  node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact| 
+  node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact|
     artefact.edition.send(field)
   end
 end
 
-node(:body, :if => lambda { |artefact| artefact.edition.respond_to?(:body) }) do |artefact| 
+node(:body, :if => lambda { |artefact| artefact.edition.respond_to?(:body) }) do |artefact|
   format_content(artefact.edition.body)
 end
 
 node(:parts, :if => lambda { |artefact| artefact.edition.respond_to?(:parts) }) do |artefact|
   partial("parts", object: artefact)
+end
+
+node(:licence, :if => lambda { |artefact| artefact.licence }) do |artefact|
+  partial("licence", object: artefact)
 end

--- a/views/_licence.rabl
+++ b/views/_licence.rabl
@@ -1,0 +1,25 @@
+node(:location_specific) {|artefact| artefact.licence['isLocationSpecific'] }
+node(:availability) {|artefact| artefact.licence['geographicalAvailability'] }
+
+node(:authorities) do |artefact|
+  if artefact.licence['issuingAuthorities']
+    artefact.licence['issuingAuthorities'].map {|authority|
+      {
+        'name' => authority['authorityName'],
+        'actions' => authority['authorityInteractions'].inject({}) {|actions, (key, links)|
+          actions[key] = links.map {|link|
+            {
+              'url' => link['url'],
+              'introduction' => link['introductionText'],
+              'description' => link['description'],
+              'payment' => link['payment']
+            }
+          }
+          actions
+        }
+      }
+    }
+  else
+    [ ]
+  end
+end


### PR DESCRIPTION
Where a LicenceEdition has a licence identifier, query the Licensify API for the licence information and available actions. If a snac code is provided, lookup the appropriate actions for the user's local authority.

The default action for when Licensify is unavailable, or times out, is to return no license at all and rescue the error, so we can at least show the licence content we have from publisher.

Note that I've mapped the api response from Licensify to new key names in the response from content api. This is for two reasons: changing from camelCase to snake_case, to bring in line with the rest of the response; and to make the keys more meaningful in the context of who and what will be consuming this api - ie "actions" is a lot simpler than "authorityInteractions" to users who may be accessing this when we expose it. I'd appreciate any feedback on this.
