### PR TITLE
Return an error key in api response when Licensify is down

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -239,8 +239,10 @@ get "/:id.json" do
         statsd.time("request.id.#{params[:id]}.licence") do
           @artefact.licence = licence_application_api.details_for_licence(@artefact.edition.licence_identifier, params[:snac])
         end
-      rescue GdsApi::TimedOutException, GdsApi::HTTPErrorResponse
-        @artefact.licence = nil
+      rescue GdsApi::TimedOutException
+        @artefact.licence = { "error" => "timed_out" }
+      rescue GdsApi::HTTPErrorResponse
+        @artefact.licence = { "error" => "http_error" }
       end
     end
 

--- a/test/integration/licence_request_test.rb
+++ b/test/integration/licence_request_test.rb
@@ -122,10 +122,10 @@ it "should not query the licence api if no licence identifier is present" do
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert ! parsed_response["details"][" licence"].present?
+    assert ! parsed_response["details"]["licence"].present?
   end
 
-  it "should not blow the stack if the api request times out" do
+  it "should return an error message if the api request times out" do
     stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
     stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
@@ -138,10 +138,11 @@ it "should not query the licence api if no licence identifier is present" do
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert ! parsed_response["details"][" licence"].present?
+    assert parsed_response["details"]["licence"].present?
+    assert_equal "timed_out", parsed_response["details"]["licence"]["error"]
   end
 
-  it "should not blow the stack if the api request returns an error" do
+  it "should return an error message if the api request returns an error" do
     stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
     stub_licence = FactoryGirl.build(:licence_edition, panopticon_id: stub_artefact.id, licence_identifier: 'blaaargh')
 
@@ -154,7 +155,8 @@ it "should not query the licence api if no licence identifier is present" do
     parsed_response = JSON.parse(last_response.body)
 
     assert last_response.ok?
-    assert ! parsed_response["details"][" licence"].present?
+    assert parsed_response["details"]["licence"].present?
+    assert_equal "http_error", parsed_response["details"]["licence"]["error"]
   end
 
 end

--- a/views/_licence.rabl
+++ b/views/_licence.rabl
@@ -1,25 +1,29 @@
-node(:location_specific) {|artefact| artefact.licence['isLocationSpecific'] }
-node(:availability) {|artefact| artefact.licence['geographicalAvailability'] }
+unless @artefact.licence["error"]
+  node(:location_specific) {|artefact| artefact.licence['isLocationSpecific'] }
+  node(:availability) {|artefact| artefact.licence['geographicalAvailability'] }
 
-node(:authorities) do |artefact|
-  if artefact.licence['issuingAuthorities']
-    artefact.licence['issuingAuthorities'].map {|authority|
-      {
-        'name' => authority['authorityName'],
-        'actions' => authority['authorityInteractions'].inject({}) {|actions, (key, links)|
-          actions[key] = links.map {|link|
-            {
-              'url' => link['url'],
-              'introduction' => link['introductionText'],
-              'description' => link['description'],
-              'payment' => link['payment']
+  node(:authorities) do |artefact|
+    if artefact.licence['issuingAuthorities']
+      artefact.licence['issuingAuthorities'].map {|authority|
+        {
+          'name' => authority['authorityName'],
+          'actions' => authority['authorityInteractions'].inject({}) {|actions, (key, links)|
+            actions[key] = links.map {|link|
+              {
+                'url' => link['url'],
+                'introduction' => link['introductionText'],
+                'description' => link['description'],
+                'payment' => link['payment']
+              }
             }
+            actions
           }
-          actions
         }
       }
-    }
-  else
-    [ ]
+    else
+      [ ]
+    end
   end
+else
+  node(:error) {|artefact| artefact.licence["error"] }
 end


### PR DESCRIPTION
As discussed with James and Dai earlier, when Licensify times out or throws a HTTP error, return an error message in the API response, so that we can distinguish this from cases where the licence actually doesn't exist.
