### PR TITLE
Fix for govspeak content_format caching

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -9,11 +9,12 @@ require 'mongoid'
 require 'govspeak'
 require 'plek'
 require 'url_helpers'
+require 'content_format_helpers'
 require 'gds_api/helpers'
 require_relative "config"
 require 'statsd'
 
-helpers URLHelpers, GdsApi::Helpers
+helpers URLHelpers, GdsApi::Helpers, ContentFormatHelpers
 
 set :views, File.expand_path('views', File.dirname(__FILE__))
 
@@ -49,14 +50,6 @@ class Artefact
 
   def live_related_artefacts
     related_artefacts.live
-  end
-end
-
-def format_content(string)
-  if @content_format == "html"
-    Govspeak::Document.new(string, auto_ids: false).to_html
-  else
-    string
   end
 end
 
@@ -222,8 +215,6 @@ get "/:id.json" do
   end
   custom_410 if @artefact && @artefact.state == 'archived'
   custom_404 unless (@artefact && @artefact.state == 'live')
-
-  @content_format = (params[:content_format] == "govspeak") ? "govspeak" : "html"
 
   if @artefact.owning_app == 'publisher'
     statsd.time("request.id.#{params[:id]}.edition") do

--- a/lib/content_format_helpers.rb
+++ b/lib/content_format_helpers.rb
@@ -1,0 +1,8 @@
+module ContentFormatHelpers
+  def format_content(string)
+    if params[:content_format] == "govspeak"
+      return string
+    end
+    Govspeak::Document.new(string, auto_ids: false).to_html
+  end
+end


### PR DESCRIPTION
Rather than setting an instance variable, check the content_format param
as needed. The logic for switching has also been extracted to a helper.
