### PR TITLE
Standardise API response fields on snake case

### DIFF
--- a/views/tags.rabl
+++ b/views/tags.rabl
@@ -6,9 +6,9 @@ end
 
 node(:description) { "Tags!" }
 node(:total) { @tags.count }
-node(:startIndex) { 1 }
-node(:pageSize) { @tags.count }
-node(:currentPage) { 1 }
+node(:start_index) { 1 }
+node(:page_size) { @tags.count }
+node(:current_page) { 1 }
 node(:pages) { 1 }
 node(:results) do
   @tags.map { |r|

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -6,9 +6,9 @@ end
 
 node(:description) { "Search for your query" }
 node(:total) { @results.count }
-node(:startIndex) { 1 }
-node(:pageSize) { @results.count }
-node(:currentPage) { 1 }
+node(:start_index) { 1 }
+node(:page_size) { @results.count }
+node(:current_page) { 1 }
 node(:pages) { 1 }
 
 node(:results) do


### PR DESCRIPTION
For some reason I used camelcase in some places and snake case in others when I built the first pass of this. Let's remove that legacy before anyone starts depending on it.
