### PR TITLE
Licences

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -49,20 +49,6 @@ class GovUkContentApi < Sinatra::Application
     render :rabl, :local_authorities, format: "json"
   end
 
-  get "/licences.?:format?" do
-    halt(404) unless params[:format].nil? or params[:format] == 'json'
-
-    licence_ids = (params[:ids] || '').split(',')
-    if licence_ids.any?
-      licences = LicenceEdition.published.in(:licence_identifier => licence_ids)
-      @results = map_editions_with_artefacts(licences)
-    else
-      @results = []
-    end
-
-    render :rabl, :licences, format: "json"
-  end
-
   get "/local_authorities/:snac.json" do
     @statsd_scope = "request.local_authority.#{params[:snac]}"
     if params[:snac]
@@ -153,6 +139,20 @@ class GovUkContentApi < Sinatra::Application
     @results = map_artefacts_and_add_editions(artefacts)
 
     render :rabl, :with_tag, format: "json"
+  end
+
+  get "/licences.?:format?" do
+    halt(404) unless params[:format].nil? or params[:format] == 'json'
+
+    licence_ids = (params[:ids] || '').split(',')
+    if licence_ids.any?
+      licences = LicenceEdition.published.in(:licence_identifier => licence_ids)
+      @results = map_editions_with_artefacts(licences)
+    else
+      @results = []
+    end
+
+    render :rabl, :licences, format: "json"
   end
 
   get "/business_support_schemes.json" do

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -49,6 +49,14 @@ class GovUkContentApi < Sinatra::Application
     render :rabl, :local_authorities, format: "json"
   end
 
+  get "/licences(.json)" do
+    licence_ids = (params[:ids] || '').split(',')
+    artefacts = Artefact.live.any_in(tag_ids: tag_ids).where(kind: 'licence')
+    @results = map_artefacts_and_add_editions(artefacts)
+
+    render :rabl, :licenses, format: "json"
+  end
+
   get "/local_authorities/:snac.json" do
     @statsd_scope = "request.local_authority.#{params[:snac]}"
     if params[:snac]

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -56,7 +56,7 @@ class GovUkContentApi < Sinatra::Application
     artefacts = Artefact.live.any_in(tag_ids: tag_ids).where(kind: 'licence')
     @results = map_artefacts_and_add_editions(artefacts)
 
-    render :rabl, :licenses, format: "json"
+    render :rabl, :licences, format: "json"
   end
 
   get "/local_authorities/:snac.json" do

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -49,7 +49,9 @@ class GovUkContentApi < Sinatra::Application
     render :rabl, :local_authorities, format: "json"
   end
 
-  get "/licences(.json)" do
+  get "/licences.?:format?" do
+    halt(404) unless params[:format].nil? or params[:format] == 'json'
+
     licence_ids = (params[:ids] || '').split(',')
     artefacts = Artefact.live.any_in(tag_ids: tag_ids).where(kind: 'licence')
     @results = map_artefacts_and_add_editions(artefacts)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -53,8 +53,12 @@ class GovUkContentApi < Sinatra::Application
     halt(404) unless params[:format].nil? or params[:format] == 'json'
 
     licence_ids = (params[:ids] || '').split(',')
-    artefacts = Artefact.live.any_in(tag_ids: tag_ids).where(kind: 'licence')
-    @results = map_artefacts_and_add_editions(artefacts)
+    if licence_ids.any?
+      licences = LicenceEdition.published.in(:licence_identifier => licence_ids)
+      @results = map_editions_with_artefacts(licences)
+    else
+      @results = []
+    end
 
     render :rabl, :licences, format: "json"
   end
@@ -191,6 +195,18 @@ class GovUkContentApi < Sinatra::Application
   end
 
   protected
+  def map_editions_with_artefacts(editions)
+    statsd.time("#{@statsd_scope}.map_editions_to_artefacts") do
+      artefact_ids = editions.collect(&:panopticon_id)
+      matching_artefacts = Artefact.live.any_in(_id: artefact_ids)
+
+      matching_artefacts.map do |artefact|
+        artefact.edition = editions.detect { |e| e.panopticon_id.to_s == artefact.id.to_s }
+        artefact
+      end
+    end
+  end
+
   def map_artefacts_and_add_editions(artefacts)
     statsd.time("#{@statsd_scope}.map_results") do
       # Preload to avoid hundreds of individual queries

--- a/test/integration/licence_application_request_test.rb
+++ b/test/integration/licence_application_request_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require "gds_api/test_helpers/licence_application"
 
-class LicenceRequestTest < GovUkContentApiTest
+class LicenceApplicationRequestTest < GovUkContentApiTest
   include GdsApi::TestHelpers::LicenceApplication
 
   it "should return full licence details for an edition with a licence identifier" do

--- a/test/integration/licence_format_test.rb
+++ b/test/integration/licence_format_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class LicenceFormatsTest < GovUkContentApiTest
+  def create_stub_licence
+    stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
+    FactoryGirl.create(:licence_edition, panopticon_id: stub_artefact.id,
+      licence_identifier: '123-2-1', state: 'published')
+  end
+
+  it "should allow requests with or without .json" do
+    get "/licences.json"
+    assert last_response.ok?, "Didn't work with .json"
+
+    get "/licences"
+    assert last_response.ok?, "Didn't work without .json"
+  end
+
+  it "should return 404 if asked for XML" do
+    get "/licences.xml"
+    assert last_response.not_found?, "Tried to respond to .xml"
+  end
+
+  it "should return an empty list if not given any IDs" do
+    get "/licences"
+    assert last_response.ok?
+    assert JSON.parse(last_response.body)['results'].empty?,
+      "List of results not found or not empty"
+  end
+
+  it "should return an empty list if none of the IDs matched" do
+    create_stub_licence
+    get "/licences?ids=abc"
+    assert last_response.ok?
+    assert JSON.parse(last_response.body)['results'].empty?,
+      "List of results not found or not empty"
+  end
+
+  it "should return a list of matching artefacts and licence details" do
+    stub_licence = create_stub_licence
+    get "/licences?ids=#{stub_licence.licence_identifier}"
+    assert last_response.ok?
+
+    parsed_response = JSON.parse(last_response.body)
+    assert_equal 1, parsed_response['results'].count
+    assert_equal stub_licence.licence_identifier,
+      parsed_response['results'].first['details']['licence_identifier']
+  end
+end

--- a/views/licences.rabl
+++ b/views/licences.rabl
@@ -1,0 +1,13 @@
+object false
+
+node :_response_info do
+  { status: "ok" }
+end
+
+node(:description) { "Licences" }
+node(:total) { @licences.count }
+node(:results) do
+  @licences.map { |licence|
+    partial "_full_artefact", object: licence
+  }
+end

--- a/views/licences.rabl
+++ b/views/licences.rabl
@@ -5,9 +5,14 @@ node :_response_info do
 end
 
 node(:description) { "Licences" }
-node(:total) { @licences.count }
+node(:total) { @results.count }
+node(:start_index) { 1 }
+node(:page_size) { @results.count }
+node(:current_page) { 1 }
+node(:pages) { 1 }
+
 node(:results) do
-  @licences.map { |licence|
-    partial "_full_artefact", object: licence
+  @results.map { |r|
+    partial "_full_artefact", object: r
   }
 end


### PR DESCRIPTION
Provide support for getting licence information as required by licence finder.

This approach actually feels unnecessary specific - we could provide equivalent methods for all publisher formats - but fills our current need. When time allows we should consider whether to generalise it.
