### PR TITLE
Record mongo errors in statsd

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -16,11 +16,17 @@ class GovUkContentApi < Sinatra::Application
   helpers URLHelpers, GdsApi::Helpers, ContentFormatHelpers
 
   set :views, File.expand_path('views', File.dirname(__FILE__))
+  set :show_exceptions, false
 
   # Register RABL
   Rabl.register!
   Rabl.configure do |c|
     c.json_engine = :yajl
+  end
+
+  error Mongo::MongoDBError, Mongo::MongoRubyError do
+    statsd.increment("mongo_error")
+    raise
   end
 
   before do


### PR DESCRIPTION
Without `set :show_exceptions, false` the error handler would never be invoked.

Did try writing a test, but difficult because using mocha to raise a mongo error would simply raise an error inline, rather than rendering an actual (error) response.
