### PR TITLE
Move updated_at to the top level of responses

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -5,6 +5,7 @@ require 'govspeak'
 require 'plek'
 require 'url_helpers'
 require 'content_format_helpers'
+require 'timestamp_helpers'
 require 'gds_api/helpers'
 require 'gds_api/rummager'
 require_relative "config"
@@ -13,7 +14,7 @@ require 'config/gds_sso_middleware'
 require 'models'
 
 class GovUkContentApi < Sinatra::Application
-  helpers URLHelpers, GdsApi::Helpers, ContentFormatHelpers
+  helpers URLHelpers, GdsApi::Helpers, ContentFormatHelpers, TimestampHelpers
 
   set :views, File.expand_path('views', File.dirname(__FILE__))
   set :show_exceptions, false

--- a/lib/timestamp_helpers.rb
+++ b/lib/timestamp_helpers.rb
@@ -1,0 +1,7 @@
+module TimestampHelpers
+  def most_recent_updated_at(artefact)
+    updated_options = [artefact.updated_at]
+    updated_options << artefact.edition.updated_at if artefact.edition
+    updated_options.compact.max
+  end
+end

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -155,7 +155,7 @@ class ArtefactRequestTest < GovUkContentApiTest
 
       assert_equal 200, last_response.status
       response = JSON.parse(last_response.body)
-      assert_equal artefact.updated_at.xmlschema, response["updated_at"]
+      assert_equal artefact.updated_at.iso8601, response["updated_at"]
     end
 
     it "should set the updated_at field from the artefact if it's most recently updated" do
@@ -166,7 +166,7 @@ class ArtefactRequestTest < GovUkContentApiTest
 
       assert_equal 200, last_response.status
       response = JSON.parse(last_response.body)
-      assert_equal artefact.updated_at.xmlschema, response["updated_at"]
+      assert_equal artefact.updated_at.iso8601, response["updated_at"]
     end
 
     it "should set the updated_at field from the edition if it's most recently updated" do
@@ -177,7 +177,7 @@ class ArtefactRequestTest < GovUkContentApiTest
 
       assert_equal 200, last_response.status
       response = JSON.parse(last_response.body)
-      assert_equal edition.updated_at.xmlschema, response["updated_at"]
+      assert_equal edition.updated_at.iso8601, response["updated_at"]
     end
   end
 
@@ -341,7 +341,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal "http://www.test.gov.uk/#{artefact.slug}", parsed_response["web_url"]
       assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
       assert_equal "1234", parsed_response["details"]["need_id"]
-      assert_equal DateTime.parse(edition.updated_at.to_s).to_s, parsed_response["updated_at"]
+      assert_equal edition.updated_at.iso8601, parsed_response["updated_at"]
       # Temporarily included for legacy GA support. Will be replaced with "proposition" Tags
       assert_equal true, parsed_response["details"]["business_proposition"]
     end

--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -10,7 +10,5 @@ node(:format) do |artefact|
 end
 node(:details) { |artefact| partial("fields", object: artefact) }
 node(:updated_at) { |artefact|
-  updated_options = [artefact.updated_at]
-  updated_options << artefact.edition.updated_at if artefact.edition
-  updated_options.compact.max.iso8601
+  most_recent_updated_at(artefact).iso8601
 }

--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -10,9 +10,7 @@ node(:format) do |artefact|
 end
 node(:details) { |artefact| partial("fields", object: artefact) }
 node(:updated_at) { |artefact|
-  if artefact.edition && artefact.edition.updated_at && artefact.edition.updated_at > artefact.updated_at
-    artefact.edition.updated_at.iso8601
-  else
-    artefact.updated_at.iso8601
-  end
+  updated_options = [artefact.updated_at]
+  updated_options << artefact.edition.updated_at if artefact.edition
+  updated_options.compact.max.iso8601
 }

--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -11,8 +11,8 @@ end
 node(:details) { |artefact| partial("fields", object: artefact) }
 node(:updated_at) { |artefact|
   if artefact.edition && artefact.edition.updated_at && artefact.edition.updated_at > artefact.updated_at
-    artefact.edition.updated_at.xmlschema
+    artefact.edition.updated_at.iso8601
   else
-    artefact.updated_at.xmlschema
+    artefact.updated_at.iso8601
   end
 }

--- a/views/_basic_artefact.rabl
+++ b/views/_basic_artefact.rabl
@@ -9,3 +9,10 @@ node(:format) do |artefact|
   end
 end
 node(:details) { |artefact| partial("fields", object: artefact) }
+node(:updated_at) { |artefact|
+  if artefact.edition && artefact.edition.updated_at && artefact.edition.updated_at > artefact.updated_at
+    artefact.edition.updated_at.xmlschema
+  else
+    artefact.updated_at.xmlschema
+  end
+}

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -6,8 +6,7 @@ node(:business_proposition) { |artefact| artefact.business_proposition }
     :video_summary, :video_url, :licence_identifier, :licence_short_description, :licence_overview,
     :lgsl_code, :lgil_override, :minutes_to_complete, :place_type,
     :eligibility, :evaluation, :additional_information,
-    :business_support_identifier, :max_employees, :organiser, :contact_details,
-    :updated_at].each do |field|
+    :business_support_identifier, :max_employees, :organiser, :contact_details].each do |field|
   node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact|
     artefact.edition.send(field)
   end


### PR DESCRIPTION
The updated timestamp is a key attribute of every artefact so makes sense
in the top level. It's also currently possible for an edition to have a more
recent updated_at value than the artefact so we should pick the latest one
to use here.
