### PR TITLE
Default allow access to unpublished content in dev

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -358,6 +358,7 @@ class GovUkContentApi < Sinatra::Application
 
   def verify_unpublished_permission
     warden = request.env['warden']
+    return if (ENV['RACK_ENV'] == "development") && ENV['REQUIRE_AUTH'].nil?
     if warden.authenticate?
       if warden.user.has_permission?(GDS::SSO::Config.default_scope, "access_unpublished")
         return true


### PR DESCRIPTION
This reinstates the development behaviour for private-frontend
before it moved to the content API (where it relied on being on
the same IP).

It means that @daibach can check stuff in dev.

To make it require auth in dev, you'd need to set REQUIRE_AUTH=1 in your shell session.
