### PR TITLE
Make licence_overview field default to html

### DIFF
--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -136,7 +136,7 @@ class FormatsRequestTest < GovUkContentApiTest
   it "should work with licence_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman-licence', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Batman licence',
-                                licence_overview: 'Not just anyone can be Batman', panopticon_id: artefact.id, state: 'published',
+                                licence_overview: 'Not just anyone can be **Batman**', panopticon_id: artefact.id, state: 'published',
                                 will_continue_on: 'The Batman', continuation_link: 'http://www.batman.com', licence_identifier: "123-4-5")
     licence_exists('123-4-5', { })
 
@@ -150,7 +150,7 @@ class FormatsRequestTest < GovUkContentApiTest
     expected_fields = ['alternative_title', 'licence_overview', 'licence_short_description', 'licence_identifier', 'will_continue_on', 'continuation_link']
 
     _assert_has_expected_fields(fields, expected_fields)
-    assert_equal "Not just anyone can be Batman", fields["licence_overview"]
+    assert_equal "<p>Not just anyone can be <strong>Batman</strong></p>\n", fields["licence_overview"]
     assert_equal "Batman licence", fields["licence_short_description"]
   end
 

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -3,13 +3,17 @@ node(:business_proposition) { |artefact| artefact.business_proposition }
 
 [:alternative_title, :overview, :more_information, :min_value, :max_value,
     :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods,
-    :video_summary, :video_url, :licence_identifier, :licence_short_description, :licence_overview,
+    :video_summary, :video_url, :licence_identifier, :licence_short_description,
     :lgsl_code, :lgil_override, :minutes_to_complete, :place_type,
     :eligibility, :evaluation, :additional_information,
     :business_support_identifier, :max_employees, :organiser, :contact_details].each do |field|
   node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact|
     artefact.edition.send(field)
   end
+end
+
+node(:licence_overview, :if => lambda { |artefact| artefact.edition.respond_to?(:licence_overview) }) do |artefact|
+  format_content(artefact.edition.licence_overview)
 end
 
 node(:body, :if => lambda { |artefact| artefact.edition.respond_to?(:body) }) do |artefact|


### PR DESCRIPTION
It was not being passed through the content formatter. Now that it is a
govspeak version can still be returned using the normal param.
