### PR TITLE
Respond to tagless `with_tag` requests with a 404.

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -134,6 +134,8 @@ class GovUkContentApi < Sinatra::Application
   get "/with_tag.json" do
     @statsd_scope = 'request.with_tag'
 
+    custom_404 if params[:tag].nil? || params[:tag].empty?
+
     if params[:include_children].to_i > 1
       custom_error(501, "Include children only supports a depth of 1.")
     end

--- a/test/requests/artefact_with_tags_request_test.rb
+++ b/test/requests/artefact_with_tags_request_test.rb
@@ -1,6 +1,17 @@
 require 'test_helper'
 
 class ArtefactWithTagsRequestTest < GovUkContentApiTest
+
+  it "should return 404 if no tag is provided" do
+    Tag.expects(:where).never
+
+    ["/with_tag.json", "/with_tag.json?tag="].each do |url|
+      get url
+      assert last_response.not_found?
+      assert_status_field "not found", last_response
+    end
+  end
+
   it "should return 404 if tag not found" do
     Tag.expects(:where).with(tag_id: 'farmers').returns([])
 


### PR DESCRIPTION
Mathematically speaking, it would probably be more correct to return a list of no results if an empty list of tags is provided, but this way is less likely to end up confusing people.
