### PR TITLE
Convert govspeak fields to HTML for API responses

### DIFF
--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -28,7 +28,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       parsed_response = JSON.parse(last_response.body)
 
       assert_equal 3, parsed_response["total"]
-      assert_equal ['Alpha desc', 'Bravo desc', 'Echo desc'], parsed_response["results"].map {|r| r["details"]["short_description"] }.sort
+      assert_equal ['<p>Alpha desc</p>', '<p>Bravo desc</p>', '<p>Echo desc</p>'], parsed_response["results"].map {|r| r["details"]["short_description"].strip }.sort
     end
 
     it "should return basic artefact details for each result" do
@@ -54,7 +54,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         assert_has_field artefact["details"], field
       end
 
-      assert_equal "Alpha desc", artefact["details"]["short_description"]
+      assert_equal "<p>Alpha desc</p>", artefact["details"]["short_description"].strip
     end
 
     it "should ignore identifiers with no matching business support edition" do
@@ -63,7 +63,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       parsed_response = JSON.parse(last_response.body)
 
       assert_equal 2, parsed_response["total"]
-      assert_equal ['Alpha desc', 'Echo desc'], parsed_response["results"].map {|r| r["details"]["short_description"] }.sort
+      assert_equal ['<p>Alpha desc</p>', '<p>Echo desc</p>'], parsed_response["results"].map {|r| r["details"]["short_description"].strip }.sort
     end
 
     it "should only return published business support editions" do
@@ -72,7 +72,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       parsed_response = JSON.parse(last_response.body)
 
       assert_equal 2, parsed_response["total"]
-      assert_equal ['Alpha desc', 'Echo desc'], parsed_response["results"].map {|r| r["details"]["short_description"] }
+      assert_equal ['<p>Alpha desc</p>', '<p>Echo desc</p>'], parsed_response["results"].map {|r| r["details"]["short_description"].strip }
     end
 
     it "should return an empty result set if nothing matches" do

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -44,7 +44,7 @@ class FormatsRequestTest < GovUkContentApiTest
   it "should work with business_support_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     business_support = FactoryGirl.create(:business_support_edition, slug: artefact.slug,
-                                short_description: "No policeman's going to give the Batmobile a ticket", min_value: 100,
+                                short_description: "No policeman is going to give the Batmobile a ticket", min_value: 100,
                                 max_value: 1000, panopticon_id: artefact.id, state: 'published',
                                 business_support_identifier: 'enterprise-finance-guarantee', max_employees: 10,
                                 organiser: "Someone", continuation_link: "http://www.example.com/scheme", will_continue_on: "Example site",
@@ -62,7 +62,7 @@ class FormatsRequestTest < GovUkContentApiTest
                         'short_description', 'min_value', 'max_value', 'eligibility', 'evaluation', 'additional_information',
                         'business_support_identifier', 'max_employees', 'organiser', 'continuation_link', 'will_continue_on', 'contact_details']
     _assert_has_expected_fields(fields, expected_fields)
-    assert_equal "No policeman's going to give the Batmobile a ticket", fields['short_description']
+    assert_equal "<p>No policeman is going to give the Batmobile a ticket</p>", fields['short_description'].strip
     assert_equal "enterprise-finance-guarantee", fields['business_support_identifier']
   end
 
@@ -150,8 +150,8 @@ class FormatsRequestTest < GovUkContentApiTest
     expected_fields = ['alternative_title', 'licence_overview', 'licence_short_description', 'licence_identifier', 'will_continue_on', 'continuation_link']
 
     _assert_has_expected_fields(fields, expected_fields)
-    assert_equal "Not just anyone can be Batman", fields["licence_overview"]
-    assert_equal "Batman licence", fields["licence_short_description"]
+    assert_equal "<p>Not just anyone can be Batman</p>", fields["licence_overview"].strip
+    assert_equal "<p>Batman licence</p>", fields["licence_short_description"].strip
   end
 
   it "should work with local_transaction_edition" do

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -1,19 +1,22 @@
 node(:need_id) { |artefact| artefact.need_id }
 node(:business_proposition) { |artefact| artefact.business_proposition }
 
-[:alternative_title, :overview, :more_information, :min_value, :max_value,
-    :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods,
-    :video_summary, :video_url, :licence_identifier, :licence_short_description, :licence_overview,
-    :lgsl_code, :lgil_override, :minutes_to_complete, :place_type,
-    :eligibility, :evaluation, :additional_information,
-    :business_support_identifier, :max_employees, :organiser, :contact_details].each do |field|
+[:alternative_title, :min_value, :max_value, :will_continue_on, 
+    :continuation_link, :link, :alternate_methods, :video_url,
+    :video_summary, :licence_identifier,  :lgsl_code, :lgil_override,
+    :minutes_to_complete, :place_type, :business_support_identifier, :max_employees,
+    :organiser, :contact_details].each do |field|
   node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact|
     artefact.edition.send(field)
   end
 end
 
-node(:body, :if => lambda { |artefact| artefact.edition.respond_to?(:body) }) do |artefact|
-  format_content(artefact.edition.body)
+[:body, :overview, :more_information, :short_description, :introduction,
+    :licence_short_description, :licence_overview, :eligibility, :evaluation, 
+    :additional_information].each do |govspeak_field|
+  node(govspeak_field, :if => lambda { |artefact| artefact.edition.respond_to?(govspeak_field) }) do |artefact|
+    format_content(artefact.edition.send(govspeak_field))
+  end
 end
 
 node(:parts, :if => lambda { |artefact| artefact.edition.respond_to?(:order_parts) }) do |artefact|


### PR DESCRIPTION
We were only converting body to HTML which makes the API responses tricky to use without access to the govspeak library. This change breaks fields into two groups: those that may contain govspeak and those that won't and converts all the former to HTML.
