### PR TITLE
Make .json mandatory on /licences.json

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -149,9 +149,7 @@ class GovUkContentApi < Sinatra::Application
     render :rabl, :with_tag, format: "json"
   end
 
-  get "/licences.?:format?" do
-    halt(404) unless params[:format].nil? or params[:format] == 'json'
-
+  get "/licences.json" do
     licence_ids = (params[:ids] || '').split(',')
     if licence_ids.any?
       licences = LicenceEdition.published.in(:licence_identifier => licence_ids)

--- a/test/requests/licence_format_test.rb
+++ b/test/requests/licence_format_test.rb
@@ -1,27 +1,17 @@
 require 'test_helper'
+require "gds_api/test_helpers/licence_application"
 
 class LicenceFormatsTest < GovUkContentApiTest
+  include GdsApi::TestHelpers::LicenceApplication
+
   def create_stub_licence
     stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
     FactoryGirl.create(:licence_edition, panopticon_id: stub_artefact.id,
       licence_identifier: '123-2-1', state: 'published')
   end
 
-  it "should allow requests with or without .json" do
-    get "/licences.json"
-    assert last_response.ok?, "Didn't work with .json"
-
-    get "/licences"
-    assert last_response.ok?, "Didn't work without .json"
-  end
-
-  it "should return 404 if asked for XML" do
-    get "/licences.xml"
-    assert last_response.not_found?, "Tried to respond to .xml"
-  end
-
   it "should return an empty list if not given any IDs" do
-    get "/licences"
+    get "/licences.json"
     assert last_response.ok?
     assert JSON.parse(last_response.body)['results'].empty?,
       "List of results not found or not empty"
@@ -29,7 +19,7 @@ class LicenceFormatsTest < GovUkContentApiTest
 
   it "should return an empty list if none of the IDs matched" do
     create_stub_licence
-    get "/licences?ids=abc"
+    get "/licences.json?ids=abc"
     assert last_response.ok?
     assert JSON.parse(last_response.body)['results'].empty?,
       "List of results not found or not empty"
@@ -37,12 +27,25 @@ class LicenceFormatsTest < GovUkContentApiTest
 
   it "should return a list of matching artefacts and licence details" do
     stub_licence = create_stub_licence
-    get "/licences?ids=#{stub_licence.licence_identifier}"
+    get "/licences.json?ids=#{stub_licence.licence_identifier}"
     assert last_response.ok?
 
     parsed_response = JSON.parse(last_response.body)
     assert_equal 1, parsed_response['results'].count
     assert_equal stub_licence.licence_identifier,
       parsed_response['results'].first['details']['licence_identifier']
+  end
+
+  it "should not clobber artefact requests that start with 'licences'" do
+    artefact = FactoryGirl.create(:artefact, slug: 'licences-to-play-music', owning_app: 'publisher', state: 'live')
+    licence_edition = FactoryGirl.create(:licence_edition, slug: artefact.slug, licence_short_description: 'Music licence',
+                                panopticon_id: artefact.id, state: 'published', licence_identifier: "123-4-5")
+    licence_exists('123-4-5', { })
+
+    get '/licences-to-play-music.json'
+    assert last_response.ok?
+
+    parsed_response = JSON.parse(last_response.body)
+    assert_equal "Music licence", parsed_response["details"]["licence_short_description"]
   end
 end


### PR DESCRIPTION
The current behaviour was swallowing /licences\* which meant that requests for e.g. /licences-to-play-music.json was returning a 404 instead of being processed by the artefact route below.

We should revisit making the .json optional across the board at a later date, and make sure it's working correctly.

This bug is currently causing all content that starts with 'licences' to 404 on the frontend.
