### PR TITLE
Pull in content_models 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '2.2.0'
+  gem 'govuk_content_models', '2.3.0'
 end
 
 gem 'gds-sso', '2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.2.0)
+    govuk_content_models (2.3.0)
       bson_ext
       differ
       gds-api-adapters
@@ -215,7 +215,7 @@ DEPENDENCIES
   gds-api-adapters (= 2.8.1)
   gds-sso (= 2.0.1)
   govspeak (= 1.0.1)
-  govuk_content_models (= 2.2.0)
+  govuk_content_models (= 2.3.0)
   minitest (= 3.4.0)
   mocha (= 0.12.4)
   plek (= 0.3.0)

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -44,8 +44,10 @@ class FormatsRequestTest < GovUkContentApiTest
   it "should work with business_support_edition" do
     artefact = FactoryGirl.create(:artefact, slug: 'batman', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     business_support = FactoryGirl.create(:business_support_edition, slug: artefact.slug,
-                                short_description: "No policeman is going to give the Batmobile a ticket", min_value: 100,
-                                max_value: 1000, panopticon_id: artefact.id, state: 'published',
+                                short_description: "No policeman is going to give the Batmobile a ticket",
+                                body: "batman body", eligibility: "batman eligibility", evaluation: "batman evaluation",
+                                additional_information: "batman additional_information",
+                                min_value: 100, max_value: 1000, panopticon_id: artefact.id, state: 'published',
                                 business_support_identifier: 'enterprise-finance-guarantee', max_employees: 10,
                                 organiser: "Someone", continuation_link: "http://www.example.com/scheme", will_continue_on: "Example site",
                                 contact_details: "Someone, somewhere")
@@ -62,8 +64,19 @@ class FormatsRequestTest < GovUkContentApiTest
                         'short_description', 'min_value', 'max_value', 'eligibility', 'evaluation', 'additional_information',
                         'business_support_identifier', 'max_employees', 'organiser', 'continuation_link', 'will_continue_on', 'contact_details']
     _assert_has_expected_fields(fields, expected_fields)
-    assert_equal "<p>No policeman is going to give the Batmobile a ticket</p>", fields['short_description'].strip
     assert_equal "enterprise-finance-guarantee", fields['business_support_identifier']
+    assert_equal "No policeman is going to give the Batmobile a ticket", fields['short_description']
+    assert_equal "<p>batman body</p>", fields['body'].strip
+    assert_equal "<p>batman eligibility</p>", fields['eligibility'].strip
+    assert_equal "<p>batman evaluation</p>", fields['evaluation'].strip
+    assert_equal "<p>batman additional_information</p>", fields['additional_information'].strip
+
+    assert_equal 100, fields["min_value"]
+    assert_equal 1000, fields["max_value"]
+    assert_equal 10, fields["max_employees"]
+    assert_equal "Someone", fields["organiser"]
+    assert_equal "Example site", fields["will_continue_on"]
+    assert_equal "http://www.example.com/scheme", fields["continuation_link"]
   end
 
   it "should work with guide_edition" do
@@ -151,15 +164,19 @@ class FormatsRequestTest < GovUkContentApiTest
 
     _assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>Not just anyone can be Batman</p>", fields["licence_overview"].strip
-    assert_equal "<p>Batman licence</p>", fields["licence_short_description"].strip
+    assert_equal "Batman licence", fields["licence_short_description"]
+    assert_equal "123-4-5", fields["licence_identifier"]
+    assert_equal "The Batman", fields["will_continue_on"]
+    assert_equal "http://www.batman.com", fields["continuation_link"]
   end
 
   it "should work with local_transaction_edition" do
-    service = FactoryGirl.create(:local_service)
+    service = FactoryGirl.create(:local_service, lgsl_code: 42)
     expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-transaction', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
-    local_transaction_edition = FactoryGirl.create(:local_transaction_edition, slug: artefact.slug, lgil_override: 3345,
+    local_transaction_edition = FactoryGirl.create(:local_transaction_edition, slug: artefact.slug, lgsl_code: 42, lgil_override: 3345,
                                 expectation_ids: [expectation.id], minutes_to_complete: 3,
+                                introduction: "batman introduction", more_information: "batman more_information",
                                 panopticon_id: artefact.id, state: 'published')
     get '/batman-transaction.json'
     parsed_response = JSON.parse(last_response.body)
@@ -172,6 +189,11 @@ class FormatsRequestTest < GovUkContentApiTest
                         'minutes_to_complete', 'expectations']
 
     _assert_has_expected_fields(fields, expected_fields)
+    assert_equal "<p>batman introduction</p>", fields["introduction"].strip
+    assert_equal "<p>batman more_information</p>", fields["more_information"].strip
+    assert_equal "3", fields["minutes_to_complete"]
+    assert_equal 42, fields["lgsl_code"]
+    assert_equal 3345, fields["lgil_override"]
   end
 
   it "should work with transaction_edition" do
@@ -179,6 +201,9 @@ class FormatsRequestTest < GovUkContentApiTest
     artefact = FactoryGirl.create(:artefact, slug: 'batman-transaction', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     transaction_edition = FactoryGirl.create(:transaction_edition, slug: artefact.slug,
                                 expectation_ids: [expectation.id], minutes_to_complete: 3,
+                                introduction: "batman introduction", more_information: "batman more_information",
+                                alternate_methods: "batman alternate_methods",
+                                will_continue_on: "A Site", link: "http://www.example.com/foo",
                                 panopticon_id: artefact.id, state: 'published')
     get '/batman-transaction.json'
     parsed_response = JSON.parse(last_response.body)
@@ -191,12 +216,20 @@ class FormatsRequestTest < GovUkContentApiTest
                         'expectations']
 
     _assert_has_expected_fields(fields, expected_fields)
+    assert_equal "<p>batman introduction</p>", fields["introduction"].strip
+    assert_equal "<p>batman more_information</p>", fields["more_information"].strip
+    assert_equal "<p>batman alternate_methods</p>", fields["alternate_methods"].strip
+    assert_equal "3", fields["minutes_to_complete"]
+    assert_equal "A Site", fields["will_continue_on"]
+    assert_equal "http://www.example.com/foo", fields["link"]
   end
 
   it "should work with place_edition" do
     expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-place', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     place_edition = FactoryGirl.create(:place_edition, slug: artefact.slug, expectation_ids: [expectation.id],
+                                introduction: "batman introduction", more_information: "batman more_information",
+                                place_type: "batman-locations",
                                 minutes_to_complete: 3, panopticon_id: artefact.id, state: 'published')
     get '/batman-place.json'
     parsed_response = JSON.parse(last_response.body)
@@ -208,6 +241,9 @@ class FormatsRequestTest < GovUkContentApiTest
     expected_fields = ['introduction', 'more_information', 'place_type', 'expectations']
 
     _assert_has_expected_fields(fields, expected_fields)
+    assert_equal "<p>batman introduction</p>", fields["introduction"].strip
+    assert_equal "<p>batman more_information</p>", fields["more_information"].strip
+    assert_equal "batman-locations", fields["place_type"]
   end
 
 end

--- a/test/requests/licence_format_test.rb
+++ b/test/requests/licence_format_test.rb
@@ -46,6 +46,6 @@ class LicenceFormatsTest < GovUkContentApiTest
     assert last_response.ok?
 
     parsed_response = JSON.parse(last_response.body)
-    assert_equal "<p>Music licence</p>", parsed_response["details"]["licence_short_description"].strip
+    assert_equal "Music licence", parsed_response["details"]["licence_short_description"]
   end
 end


### PR DESCRIPTION
This refines the specification of which fields are govspeak.

Also added tests for the govspeakness or not of the various output fields.
