### PR TITLE
Add identifier field to business support schemes

### DIFF
--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -45,6 +45,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       assert_has_field artefact, 'web_url'
       assert_has_field artefact, 'short_description'
       assert_has_field artefact, 'format'
+      assert_has_field artefact, 'identifier'
 
       assert_equal "Alpha desc", artefact["short_description"]
     end

--- a/views/business_support_schemes.rabl
+++ b/views/business_support_schemes.rabl
@@ -11,6 +11,7 @@ node(:results) do
     {
       :id => artefact_url(r),
       :web_url => artefact_web_url(r),
+      :identifier => r.edition.business_support_identifier,
       :title => r.edition.title,
       :short_description => r.edition.short_description,
       :format => r.kind 


### PR DESCRIPTION
Allows business-support-finder to maintain the same order for schemes as is returned from the imminence api. https://github.com/alphagov/imminence/commit/87738a888777f6c77971526662548819dc275499
