### PR TITLE
Append local service details to licence editions from Licensify

### DIFF
--- a/views/_licence.rabl
+++ b/views/_licence.rabl
@@ -26,6 +26,9 @@ unless @artefact.licence["error"]
       [ ]
     end
   end
+  if @artefact.licence['local_service']
+    node(:local_service) {|artefact| artefact.licence['local_service'] }
+  end
 else
   node(:error) {|artefact| artefact.licence["error"] }
 end


### PR DESCRIPTION
Where available, match the licence identifier to the appropriate local service from Local Directgov so that Frontend will be able to send the user to the most appropriate authority for the licence if possible, as opposed to just the closest.
