### PR TITLE
Fix frequent timeouts/Increase number of unicorn processes

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -3,4 +3,4 @@ def load_file_if_exists(config, file)
 end
 load_file_if_exists(self, "/etc/govuk/unicorn.rb")
 working_directory File.dirname(File.dirname(__FILE__))
-worker_processes 4
+worker_processes 8


### PR DESCRIPTION
This should reduce the frequency of requests timing out in apps using the
content API (eg frontend, smart answers).

Our hypothesis is that the content API is simply too busy, so some requests are
queued for several seconds before the app is available. The logs for timed out
requests seem to agree with this (long nginx request duration, short app
request duration).
