### PR TITLE
Fix travel advice country api endpoints

### DIFF
--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -77,10 +77,10 @@ module URLHelpers
   end
 
   def country_url(country)
-    api_url(CGI.escape "travel-advice/#{country.slug}.json")
+    api_url("/" + CGI.escape("travel-advice/#{country.slug}.json") )
   end
 
   def country_web_url(country)
-    "#{ENV["GOVUK_WEBSITE_ROOT"]}/travel-advice/#{country.slug}"
+    public_web_url "/travel-advice/#{country.slug}"
   end
 end


### PR DESCRIPTION
Travel advice country api endpoint urls break when there's an
api prefix in the URL, due to the lack of a trailing slash.

This also swaps out the use of `GOVUK_WEBSITE_ROOT` for the
`public_web_url` helper.
