### PR TITLE
Add authentication to the asset_manager_api calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'gds-sso', '3.0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '5.2.0'
+  gem 'gds-api-adapters', '5.3.0'
 end
 
 gem 'govspeak', '1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    gds-api-adapters (5.2.0)
+    gds-api-adapters (5.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -220,7 +220,7 @@ DEPENDENCIES
   ci_reporter (= 1.7.0)
   database_cleaner (= 0.7.2)
   factory_girl (= 3.6.1)
-  gds-api-adapters (= 5.2.0)
+  gds-api-adapters (= 5.3.0)
   gds-sso (= 3.0.1)
   govspeak (= 1.0.1)
   govuk_content_models (= 4.9.1)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -567,6 +567,11 @@ class GovUkContentApi < Sinatra::Application
     end
   end
 
+  def asset_manager_api
+    options = Object::const_defined?(:API_CLIENT_CREDENTIALS) ? API_CLIENT_CREDENTIALS : {}
+    super(options)
+  end
+
   # Initialise statsd
   def statsd
     @statsd ||= Statsd.new("localhost").tap do |c|


### PR DESCRIPTION
Calls for travel-advice content with assets fail without this being setup.
