### PR TITLE
Expose extended font flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'omniauth-gds', '0.0.3' #rubygems doesn't seem to pull this in transitively
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '4.9.1'
+  gem 'govuk_content_models', '4.11.0'
 end
 
 gem 'gds-sso', '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.9.1)
+    govuk_content_models (4.11.0)
       bson_ext
       differ
       gds-api-adapters
@@ -223,7 +223,7 @@ DEPENDENCIES
   gds-api-adapters (= 5.3.0)
   gds-sso (= 3.0.1)
   govspeak (= 1.0.1)
-  govuk_content_models (= 4.9.1)
+  govuk_content_models (= 4.11.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/env.rb
+++ b/env.rb
@@ -1,1 +1,2 @@
+Time.zone = "London"
 ENV["RACK_ENV"] ||= "development"

--- a/mongoid.yml
+++ b/mongoid.yml
@@ -2,7 +2,9 @@ development:
   host: localhost
   database: govuk_content_development
   logger: true
+  use_activesupport_time_zone: true
 test:
   host: localhost
   database: govuk_content_shared_test
   logger: false
+  use_activesupport_time_zone: true

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -22,7 +22,7 @@ class FormatsRequestTest < GovUkContentApiTest
 
     fields = parsed_response["details"]
 
-    expected_fields = ['description', 'alternative_title', 'body']
+    expected_fields = ['description', 'alternative_title', 'body', 'need_extended_font']
 
     assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>Important batman information</p>\n", fields["body"]

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -2,6 +2,7 @@ node(:need_id) { |artefact| artefact.need_id }
 node(:business_proposition) { |artefact| artefact.business_proposition }
 node(:description) { |artefact| artefact.description }
 node(:language) { |artefact| artefact.language }
+node(:need_extended_font) { |artefact| artefact.need_extended_font }
 
 [:body, :alternative_title, :more_information, :min_value, :max_value,
     :short_description, :introduction, :will_continue_on, :continuation_link, :link, :alternate_methods,


### PR DESCRIPTION
This follows on (but is not dependent on) this Panopticon PR:
https://github.com/alphagov/panopticon/pull/66

Pivotal: https://www.pivotaltracker.com/story/show/46101529

This exposes the flag in the JSON response that contentapi returns.
