### PR TITLE
Don't require % encoded /'s for travel-advice artefacts.

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -351,12 +351,12 @@ class GovUkContentApi < Sinatra::Application
     render :rabl, :artefacts, format: "json"
   end
 
-  get "/:id.json" do
+  get "/*.json" do |id|
     @statsd_scope = "request.artefact"
     verify_unpublished_permission if params[:edition]
 
     statsd.time(@statsd_scope) do
-      @artefact = Artefact.find_by_slug(CGI.unescape(params[:id]))
+      @artefact = Artefact.find_by_slug(id)
     end
 
     custom_404 unless @artefact

--- a/test/requests/travel_advice_test.rb
+++ b/test/requests/travel_advice_test.rb
@@ -103,7 +103,7 @@ class TravelAdviceTest < GovUkContentApiTest
         edition.publish!
       end
 
-      get '/foreign-travel-advice%2Faruba.json'
+      get '/foreign-travel-advice/aruba.json'
       assert last_response.ok?
 
       parsed_response = JSON.parse(last_response.body)
@@ -158,7 +158,7 @@ class TravelAdviceTest < GovUkContentApiTest
         aruba_edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'aruba')
 
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -189,7 +189,7 @@ class TravelAdviceTest < GovUkContentApiTest
         aruba_edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'aruba')
 
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -218,7 +218,7 @@ class TravelAdviceTest < GovUkContentApiTest
         aruba_edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'aruba')
 
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -253,7 +253,7 @@ class TravelAdviceTest < GovUkContentApiTest
           "state" => "clean",
         })
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -284,7 +284,7 @@ class TravelAdviceTest < GovUkContentApiTest
           "state" => "clean",
         })
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -318,7 +318,7 @@ class TravelAdviceTest < GovUkContentApiTest
           "state" => "infected",
         })
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         parsed_response = JSON.parse(last_response.body)
@@ -345,7 +345,7 @@ class TravelAdviceTest < GovUkContentApiTest
           "state" => "clean",
         })
 
-        get '/foreign-travel-advice%2Faruba.json'
+        get '/foreign-travel-advice/aruba.json'
         assert last_response.ok?
 
         assert_requested(:get, %r{\A#{ASSET_MANAGER_ENDPOINT}}, :headers => {"Authorization" => "Bearer foobar"})
@@ -371,7 +371,7 @@ class TravelAdviceTest < GovUkContentApiTest
       Warden::Proxy.any_instance.expects(:authenticate?).returns(true)
       Warden::Proxy.any_instance.expects(:user).returns(ReadOnlyUser.new("permissions" => ["access_unpublished"]))
 
-      get '/foreign-travel-advice%2Faruba.json?edition=1'
+      get '/foreign-travel-advice/aruba.json?edition=1'
       assert last_response.ok?
 
       parsed_response = JSON.parse(last_response.body)
@@ -407,17 +407,17 @@ class TravelAdviceTest < GovUkContentApiTest
       edition.parts.build(title: "Part One", slug: 'part-one', body: "This is part one\n------\n")
       edition.save!
 
-      get '/foreign-travel-advice%2Faruba.json'
+      get '/foreign-travel-advice/aruba.json'
       assert last_response.not_found?
     end
 
     it "should 404 for a country with no published advice" do
-      get '/foreign-travel-advice%2Fangola.json'
+      get '/foreign-travel-advice/angola.json'
       assert last_response.not_found?
     end
 
     it "should 404 for a non-existent country" do
-      get '/foreign-travel-advice%2Fwibble.json'
+      get '/foreign-travel-advice/wibble.json'
       assert last_response.not_found?
     end
   end

--- a/test/requests/travel_advice_test.rb
+++ b/test/requests/travel_advice_test.rb
@@ -135,6 +135,26 @@ class TravelAdviceTest < GovUkContentApiTest
       assert_equal "<p>And some more stuff in part 2.</p>", parts[1]["body"].strip
     end
 
+    it "should work with % encoded slugs" do
+      artefact = FactoryGirl.create(:artefact, slug: 'foreign-travel-advice/aruba', state: 'live',
+                                    kind: 'travel-advice', owning_app: 'travel-advice-publisher', name: "Aruba travel advice",
+                                    description: "This is the travel advice for people planning a visit to Aruba.")
+      edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'aruba',
+                                  title: "Travel advice for Aruba", overview: "This is the travel advice for people planning a visit to Aruba.",
+                                  change_description: "Some stuff changed",
+                                  summary: "This is the summary\n------\n",
+                                  alert_status: ["avoid_all_but_essential_travel_to_parts","avoid_all_travel_to_parts"])
+
+      get '/foreign-travel-advice%2Faruba.json'
+      assert last_response.ok?
+
+      parsed_response = JSON.parse(last_response.body)
+
+      assert_base_artefact_fields(parsed_response)
+      assert_equal 'travel-advice', parsed_response["format"]
+      assert_equal 'Travel advice for Aruba', parsed_response["title"]
+    end
+
     describe "loading related links data" do
 
       it "should include related links from the foreign-travel-advice index page" do


### PR DESCRIPTION
This will allow proxying requests for these artefacts through the public api proxy to work.

Would be good for someone from publishing platform to review this.
