### PR TITLE
Fix rendering with_tag.json with foreign-travel-advice

### DIFF
--- a/test/requests/artefact_with_tags_request_test.rb
+++ b/test/requests/artefact_with_tags_request_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ArtefactWithTagsRequestTest < GovUkContentApiTest
 
@@ -79,6 +79,16 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
   it "should return an array of results" do
     farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
     FactoryGirl.create(:artefact, owning_app: "smart-answers", keywords: ['farmers'], state: 'live')
+
+    get "/with_tag.json?keyword=farmers"
+
+    assert last_response.ok?
+    assert_equal 1, JSON.parse(last_response.body)["results"].count
+  end
+
+  it "should not be broken by the foreign-travel-advice special handling" do
+    farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
+    FactoryGirl.create(:artefact, slug: 'foreign-travel-advice', owning_app: "travel-advice-publisher", keywords: ['farmers'], state: 'live')
 
     get "/with_tag.json?keyword=farmers"
 

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -82,7 +82,7 @@ node(:country, :if => lambda { |artefact| artefact.country.is_a?(Country) }) do 
   }
 end
 
-node(:countries, :if => lambda { |artefact| artefact.slug == 'foreign-travel-advice' }) do |artefact|
+node(:countries, :if => lambda { |artefact| @countries and artefact.slug == 'foreign-travel-advice' }) do |artefact|
   @countries.map do |c|
     {
       :id => country_url(c),


### PR DESCRIPTION
The foreign-travel-advice artefact has some special handling that was
breaking in this view.
