### PR TITLE
Set the version of thin required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,5 +44,5 @@ end
 group :development do
   gem "shotgun"
   # Use thin because WEBrick has a URL length limit of 1024, and shotgun doesn't support unicorn
-  gem "thin"
+  gem 'thin', '1.5.1'
 end


### PR DESCRIPTION
Version 1.3.1 of thin has issues when compiling (https://github.com/macournoyer/thin/issues/119). So It's better if it's avoided. Version 1.5.1 works
