### PR TITLE
Stop mangling recommended links

### DIFF
--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -40,7 +40,11 @@ module URLHelpers
   end
 
   def search_result_url(result)
-    api_url(result['link']) + ".json"
+    if result['link'].start_with?("http")
+      nil
+    else
+      api_url(result['link']) + ".json"
+    end
   end
 
   def search_result_web_url(result)

--- a/test/requests/search_request_test.rb
+++ b/test/requests/search_request_test.rb
@@ -106,4 +106,24 @@ class SearchRequestTest < GovUkContentApiTest
     parsed_response = JSON.parse(last_response.body)
     assert_equal 'http://www.nhs.uk/ehic', parsed_response["results"].first['web_url']
   end
+
+  it "should omit id values for recommended-links (off-site links)" do
+    rummager_response = [
+      {
+        "title" => "EHIC - NHS Choices",
+        "description" => "Apply for a free European Health Insurance Card (EHIC) or renew your card for emergency healthcare in Europe",
+        "format" => "recommended-link",
+        "link" => "http://www.nhs.uk/ehic",
+        "indexable_content" => "ehic, e111, european health insurance card, european health card, travel abroad, travel insurance",
+        "es_score" => 3.3209536,
+        "highlight" => nil,
+        "presentation_format" => "recommended_link",
+        "humanized_format" => "Recommended links"}
+    ]
+    GdsApi::Rummager.any_instance.stubs(:search).returns(rummager_response)
+    get "/search.json?q=ehic"
+
+    parsed_response = JSON.parse(last_response.body)
+    assert_equal nil, parsed_response["results"].first['id']
+  end
 end


### PR DESCRIPTION
The Content API currently mangles recommended links (or any off-site link in the results), for example: https://www.gov.uk/api/search.json?q=ehic

This is probably annoying to third parties, and hinders us from using the Content API for search results ourselves.
