### PR TITLE
Improve performance of /with_tag.json endpoint

### DIFF
--- a/test/requests/artefact_with_tags_request_test.rb
+++ b/test/requests/artefact_with_tags_request_test.rb
@@ -2,189 +2,218 @@ require_relative '../test_helper'
 
 class ArtefactWithTagsRequestTest < GovUkContentApiTest
 
-  it "should return 404 if no tag is provided" do
-    Tag.expects(:where).never
+  describe "handling requests with a tag= parameter" do
+    it "should return 404 if no tag is provided" do
+      Tag.expects(:where).never
 
-    ["/with_tag.json", "/with_tag.json?tag="].each do |url|
-      get url
+      ["/with_tag.json", "/with_tag.json?tag="].each do |url|
+        get url
+        assert last_response.not_found?
+        assert_status_field "not found", last_response
+      end
+    end
+
+    it "should return 404 if tag not found" do
+      Tag.expects(:where).with(tag_id: 'farmers').returns([])
+
+      get "/with_tag.json?tag=farmers"
+
+      assert last_response.not_found?
+      assert_status_field "not found", last_response
+    end
+
+    it "should return 404 if multiple tags found" do
+      tags = %w(section keyword).map { |tag_type|
+        Tag.new(tag_id: "ambiguity", title: "Ambiguity", tag_type: tag_type)
+      }
+      Tag.expects(:where).with(tag_id: "ambiguity").returns(tags)
+
+      get "/with_tag.json?tag=ambiguity"
+
+      assert last_response.not_found?
+      assert_status_field "not found", last_response
+    end
+
+    it "should redirect to the typed URL with zero results" do
+      t = Tag.new(tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
+      Tag.stubs(:where).with(tag_id: 'farmers').returns([t])
+
+      get "/with_tag.json?tag=farmers"
+      assert last_response.redirect?
+      assert_equal(
+        "http://example.org/with_tag.json?keyword=farmers",
+        last_response.location
+      )
+    end
+
+    it "should redirect to the typed URL with multiple results" do
+      farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
+      FactoryGirl.create(:artefact, owning_app: "smart-answers", keywords: ['farmers'], state: 'live')
+
+      get "/with_tag.json?tag=farmers"
+      assert_equal(
+        "http://example.org/with_tag.json?keyword=farmers",
+        last_response.location
+      )
+    end
+
+    it "should preserve the specified sort order when redirecting" do
+      batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
+      get "/with_tag.json?tag=batman&sort=bobbles"
+      assert last_response.redirect?
+      assert_equal(
+        "http://example.org/with_tag.json?section=batman&sort=bobbles",
+        last_response.location
+      )
+    end
+
+    it "should preserve the include_children options when redirecting" do
+      batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
+      get "/with_tag.json?tag=batman&include_children=1"
+      assert last_response.redirect?
+      assert_equal(
+        "http://example.org/with_tag.json?section=batman&include_children=1",
+        last_response.location
+      )
+    end
+
+    it "should not allow filtering by multiple tags" do
+      farmers = FactoryGirl.create(:tag, tag_id: 'crime', title: 'Crime', tag_type: 'section')
+      business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
+
+      get "/with_tag.json?tag=crime,business"
       assert last_response.not_found?
       assert_status_field "not found", last_response
     end
   end
 
-  it "should return 404 if tag not found" do
-    Tag.expects(:where).with(tag_id: 'farmers').returns([])
+  describe "handling requests for typed tags" do
+    describe "with a valid request" do
+      before :each do
+        @farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
+        @business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
+      end
 
-    get "/with_tag.json?tag=farmers"
+      it "should return an array of results" do
+        artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", keywords: ['farmers'], state: 'live',
+                                     description: "Artefact description")
 
-    assert last_response.not_found?
-    assert_status_field "not found", last_response
-  end
+        get "/with_tag.json?keyword=farmers"
 
-  it "should return 404 if multiple tags found" do
-    tags = %w(section keyword).map { |tag_type|
-      Tag.new(tag_id: "ambiguity", title: "Ambiguity", tag_type: tag_type)
-    }
-    Tag.expects(:where).with(tag_id: "ambiguity").returns(tags)
+        assert last_response.ok?
+        assert_status_field "ok", last_response
+        parsed_response = JSON.parse(last_response.body)
+        assert_equal 1, parsed_response["results"].count
 
-    get "/with_tag.json?tag=ambiguity"
+        details = parsed_response["results"].first
+        assert_equal artefact.name, details["title"]
+        assert_equal artefact.description, details["details"]["description"]
+      end
 
-    assert last_response.not_found?
-    assert_status_field "not found", last_response
-  end
+      it "should return the standard response even if zero results" do
+        get "/with_tag.json?keyword=farmers"
+        parsed_response = JSON.parse(last_response.body)
 
-  it "should return 404 if typed tag not found" do
-    Tag.expects(:by_tag_id).with("farmers", "keyword").returns(nil)
+        assert last_response.ok?
+        assert_status_field "ok", last_response
+        assert_equal 0, parsed_response["total"]
+        assert_equal [], parsed_response["results"]
+      end
 
-    get "/with_tag.json?keyword=farmers"
+      it "should not be broken by the foreign-travel-advice special handling" do
+        FactoryGirl.create(:artefact, slug: 'foreign-travel-advice', owning_app: "travel-advice-publisher", keywords: ['farmers'], state: 'live')
 
-    assert last_response.not_found?
-    assert_status_field "not found", last_response
-  end
+        get "/with_tag.json?keyword=farmers"
 
-  it "should redirect to the typed URL with zero results" do
-    t = Tag.new(tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
-    Tag.stubs(:where).with(tag_id: 'farmers').returns([t])
+        assert last_response.ok?
+        assert_equal 1, JSON.parse(last_response.body)["results"].count
+      end
 
-    get "/with_tag.json?tag=farmers"
-    assert last_response.redirect?
-    assert_equal(
-      "http://example.org/with_tag.json?keyword=farmers",
-      last_response.location
-    )
-  end
+      it "should exclude artefacts which aren't live" do
+        draft    = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'draft')
+        live     = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'live')
+        archived = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'archived')
 
-  it "should return the standard response even if zero results" do
-    FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
+        get "/with_tag.json?keyword=farmers"
 
-    get "/with_tag.json?keyword=farmers"
-    parsed_response = JSON.parse(last_response.body)
+        assert last_response.ok?
+        response = JSON.parse(last_response.body)
+        assert_equal 1, response["results"].count
+        assert_equal "http://example.org/#{live.slug}.json", response["results"][0]["id"]
+      end
 
-    assert last_response.ok?
-    assert_status_field "ok", last_response
-    assert_equal 0, parsed_response["total"]
-  end
+      it "should exclude unpublished publisher items" do
+        artefact = FactoryGirl.create(:artefact, owning_app: "publisher", sections: ['business'])
+        FactoryGirl.create(:edition, panopticon_id: artefact.id, state: "ready")
 
-  it "should redirect to the typed URL with multiple results" do
-    farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
-    FactoryGirl.create(:artefact, owning_app: "smart-answers", keywords: ['farmers'], state: 'live')
+        get "/with_tag.json?section=business"
 
-    get "/with_tag.json?tag=farmers"
-    assert_equal(
-      "http://example.org/with_tag.json?keyword=farmers",
-      last_response.location
-    )
-  end
+        assert last_response.ok?, "request failed: #{last_response.status}"
+        assert_equal 0, JSON.parse(last_response.body)["results"].count
+      end
 
-  it "should return an array of results" do
-    farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
-    FactoryGirl.create(:artefact, owning_app: "smart-answers", keywords: ['farmers'], state: 'live')
+      describe "including chiuldren in results" do
+        before :each do
+          @foo = FactoryGirl.create(:tag, tag_id: 'foo', title: 'Business', tag_type: 'section', parent_id: "business")
+          @bar = FactoryGirl.create(:tag, tag_id: 'bar', title: 'Bar', tag_type: 'section', parent_id: nil)
+          @business_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['business'], state: 'live')
+          @foo_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['foo'], state: 'live')
+          @bar_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['bar'], state: 'live')
+        end
 
-    get "/with_tag.json?keyword=farmers"
+        it "should not include any children by default" do
+          get "/with_tag.json?section=business"
 
-    assert last_response.ok?
-    assert_equal 1, JSON.parse(last_response.body)["results"].count
-  end
+          assert last_response.ok?
+          parsed_response = JSON.parse(last_response.body)
+          assert_equal 1, parsed_response["results"].count
+          assert_equal "http://example.org/#{@business_artefact.slug}.json", parsed_response["results"][0]["id"]
+        end
 
-  it "should not be broken by the foreign-travel-advice special handling" do
-    farmers = FactoryGirl.create(:tag, tag_id: 'farmers', title: 'Farmers', tag_type: 'keyword')
-    FactoryGirl.create(:artefact, slug: 'foreign-travel-advice', owning_app: "travel-advice-publisher", keywords: ['farmers'], state: 'live')
+        it "should return include children in array of results" do
+          get "/with_tag.json?section=business&include_children=1"
 
-    get "/with_tag.json?keyword=farmers"
+          assert last_response.ok?
+          assert_equal 2, JSON.parse(last_response.body)["results"].count
+        end
 
-    assert last_response.ok?
-    assert_equal 1, JSON.parse(last_response.body)["results"].count
-  end
+        it "should return 501 if more than 1 child requested" do
+          get "/with_tag.json?section=business&include_children=2"
 
-  it "should redirect with a bad sort order specified" do
-    batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
-    get "/with_tag.json?tag=batman&sort=bobbles"
-    assert last_response.redirect?
-    assert_equal(
-      "http://example.org/with_tag.json?section=batman&sort=bobbles",
-      last_response.location
-    )
-  end
+          assert_equal 501, last_response.status
+          assert_status_field "Include children only supports a depth of 1.", last_response
+        end
+      end
+    end
 
-  it "should redirect with a good sort order specified" do
-    batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
-    get "/with_tag.json?tag=batman&sort=curated"
-    assert last_response.redirect?
-    assert_equal(
-      "http://example.org/with_tag.json?section=batman&sort=curated",
-      last_response.location
-    )
-  end
+    describe "error handling" do
+      it "should return 404 if typed tag not found" do
+        Tag.expects(:by_tag_id).with("farmers", "keyword").returns(nil)
 
-  it "should return a 404 if an unsupported sort order is requested" do
-    batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
-    bat = FactoryGirl.create(:artefact, owning_app: 'publisher', sections: ['batman'], name: 'Bat', slug: 'batman')
-    bat_guide = FactoryGirl.create(:guide_edition, panopticon_id: bat.id, state: "published", slug: 'batman')
-    get "/with_tag.json?section=batman&sort=bobbles"
+        get "/with_tag.json?keyword=farmers"
 
-    assert last_response.not_found?
-    assert_status_field "not found", last_response
-  end
+        assert last_response.not_found?
+        assert_status_field "not found", last_response
+      end
 
-  it "should exclude artefacts which aren't live" do
-    FactoryGirl.create(:tag, tag_id: 'farmers', tag_type: 'keyword')
-    draft    = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'draft')
-    live     = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'live')
-    archived = FactoryGirl.create(:non_publisher_artefact, keywords: ['farmers'], state: 'archived')
+      it "should return a 404 if an unsupported sort order is requested" do
+        batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
+        bat = FactoryGirl.create(:artefact, owning_app: 'publisher', sections: ['batman'], name: 'Bat', slug: 'batman')
+        bat_guide = FactoryGirl.create(:guide_edition, panopticon_id: bat.id, state: "published", slug: 'batman')
+        get "/with_tag.json?section=batman&sort=bobbles"
 
-    get "/with_tag.json?keyword=farmers"
+        assert last_response.not_found?
+        assert_status_field "not found", last_response
+      end
 
-    assert last_response.ok?
-    response = JSON.parse(last_response.body)
-    assert_equal 1, response["results"].count
-    assert_equal "http://example.org/#{live.slug}.json", response["results"][0]["id"]
-  end
+      it "should not allow filtering by multiple typed tags" do
+        farmers = FactoryGirl.create(:tag, tag_id: 'crime', title: 'Crime', tag_type: 'section')
+        business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
 
-  it "should exclude unpublished publisher items" do
-    business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
-    artefact = FactoryGirl.create(:artefact, owning_app: "publisher", sections: ['business'])
-    FactoryGirl.create(:edition, panopticon_id: artefact.id, state: "ready")
-
-    get "/with_tag.json?section=business"
-
-    assert last_response.ok?, "request failed: #{last_response.status}"
-    assert_equal 0, JSON.parse(last_response.body)["results"].count
-  end
-
-  it "should not allow filtering by multiple tags" do
-    farmers = FactoryGirl.create(:tag, tag_id: 'crime', title: 'Crime', tag_type: 'section')
-    business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
-
-    get "/with_tag.json?tag=crime,business"
-    assert last_response.not_found?
-  end
-
-  it "should not allow filtering by multiple typed tags" do
-    farmers = FactoryGirl.create(:tag, tag_id: 'crime', title: 'Crime', tag_type: 'section')
-    business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
-
-    get "/with_tag.json?section=crime,business"
-    assert last_response.not_found?
-  end
-
-  it "should return include children in array of results" do
-    FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
-    FactoryGirl.create(:tag, tag_id: 'foo', title: 'Business', tag_type: 'section', parent_id: "business")
-    FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['business'], state: 'live')
-    FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['foo'], state: 'live')
-
-    get "/with_tag.json?section=business&include_children=1"
-
-    assert last_response.ok?
-    assert_equal 2, JSON.parse(last_response.body)["results"].count
-  end
-
-  it "should return 501 if more than 1 child requested" do
-    tag = Tag.new(tag_id: "business", title: "Business", tag_type: "section")
-    Tag.stubs(:by_tag_id).with("business", "section").returns([tag])
-
-    get "/with_tag.json?section=business&include_children=2"
-
-    assert_equal 501, last_response.status
+        get "/with_tag.json?section=crime,business"
+        assert last_response.not_found?
+        assert_status_field "not found", last_response
+      end
+    end
   end
 end

--- a/test/requests/licence_format_test.rb
+++ b/test/requests/licence_format_test.rb
@@ -7,7 +7,7 @@ class LicenceFormatsTest < GovUkContentApiTest
   def create_stub_licence
     stub_artefact = FactoryGirl.create(:artefact, slug: 'licence-artefact', state: 'live')
     FactoryGirl.create(:licence_edition, panopticon_id: stub_artefact.id,
-      licence_identifier: '123-2-1', state: 'published')
+      licence_identifier: '123-2-1', licence_short_description: "A licence for stuff", state: 'published')
   end
 
   it "should return an empty list if not given any IDs" do
@@ -42,6 +42,8 @@ class LicenceFormatsTest < GovUkContentApiTest
     assert_equal 1, parsed_response['results'].count
     assert_equal stub_licence.licence_identifier,
       parsed_response['results'].first['details']['licence_identifier']
+    assert_equal stub_licence.licence_short_description,
+      parsed_response['results'].first['details']['licence_short_description']
 
     assert_has_values parsed_response, "total" => 1, "current_page" => 1,
                                        "pages" => 1

--- a/views/_full_artefact.rabl
+++ b/views/_full_artefact.rabl
@@ -1,3 +1,0 @@
-extends "_basic_artefact"
-
-node(:details) { |artefact| partial("fields", object: artefact) }

--- a/views/_full_artefact.rabl
+++ b/views/_full_artefact.rabl
@@ -1,11 +1,3 @@
 extends "_basic_artefact"
 
 node(:details) { |artefact| partial("fields", object: artefact) }
-
-child :tags => :tags do
-  extends "_tag"
-end
-
-child :live_related_artefacts => :related do
-  extends "_basic_artefact"
-end

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -5,7 +5,11 @@ node :_response_info do
 end
 
 glue @artefact do
-  extends "_full_artefact", object: @artefact
+  extends "_basic_artefact"
+end
+
+child @artefact => :details do
+  extends "_fields"
 end
 
 child @artefact.tags => :tags do

--- a/views/artefact.rabl
+++ b/views/artefact.rabl
@@ -7,3 +7,11 @@ end
 glue @artefact do
   extends "_full_artefact", object: @artefact
 end
+
+child @artefact.tags => :tags do
+  extends "_tag"
+end
+
+child @artefact.live_related_artefacts => :related do
+  extends "_basic_artefact"
+end

--- a/views/licences.rabl
+++ b/views/licences.rabl
@@ -4,5 +4,11 @@ object @result_set
 node(:description) { "Licences" }
 
 child(:results => "results") do
-  extends "_full_artefact"
+  extends "_basic_artefact"
+  node :details do |artefact|
+    {
+      "licence_identifier" => artefact.edition.licence_identifier,
+      "licence_short_description" => artefact.edition.licence_short_description,
+    }
+  end
 end

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -3,8 +3,11 @@ object @result_set
 
 node(:description) { @description }
 
-node(:results) do
-  @result_set.results.map { |r|
-    partial "_full_artefact", object: r
-  }
+child(:results => "results") do
+  extends "_basic_artefact"
+  node :details do |artefact|
+    {
+      "description" => artefact.description,
+    }
+  end
 end


### PR DESCRIPTION
This changes the `/with_tag.json` endpoint to only return the details necessary for the browse pages (top-level details + description field).

Some crude tests on my dev VM produced the following:

`ab -n 10 -c 1 'http://contentapi.dev.gov.uk/with_tag.json?section=driving%2Fteaching-people-to-drive'`

Original code:

```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:  3431 3923 350.7   4065    4417
Waiting:     3430 3922 350.7   4064    4416
Total:       3431 3923 350.7   4065    4417
```

New code:

```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   157  177  14.5    178     195
Waiting:      157  177  14.5    178     195
Total:        157  177  14.5    178     195
```

Digging revealed that there were 2 things that were causing the slowdown:
1. Loading in all the related artefacts and tags
2. Processing the Govspeak fields

These added around 2s each.
