### PR TITLE
Remove the include_children option from /with_tags

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -243,8 +243,6 @@ class GovUkContentApi < Sinatra::Application
   #
   #   /with_tag.json?section=crime
   #    - all artefacts in the Crime section
-  #   /with_tag.json?section=crime&include_children=1
-  #    - all artefacts in the Crime section and any subsections
   #   /with_tag.json?section=crime&sort=curated
   #    - all artefacts in the Crime section, with any curated ones first
   get "/with_tag.json" do
@@ -252,7 +250,7 @@ class GovUkContentApi < Sinatra::Application
 
     @statsd_scope = 'request.with_tag'
 
-    modifiers = %w(include_children sort)
+    modifiers = %w(sort)
 
     unless params[:tag].blank?
       # Old-style tag URLs without types specified
@@ -287,12 +285,6 @@ class GovUkContentApi < Sinatra::Application
     # For now, we only support retrieving by a single tag
     custom_404 unless requested_tags.size == 1
 
-    if params[:include_children].to_i > 1
-      custom_error(501, "Include children only supports a depth of 1.")
-    elsif params[:include_children].to_i == 1
-      requested_tags = include_children(requested_tags)
-    end
-
     if params[:sort]
       custom_404 unless ["curated", "alphabetical"].include?(params[:sort])
     end
@@ -300,12 +292,9 @@ class GovUkContentApi < Sinatra::Application
     tag_id = requested_tags.first.tag_id
     tag_type = requested_tags.first.tag_type
     @description = "All content with the '#{tag_id}' #{tag_type}"
-    if params[:include_children]
-      @description += " and subsections"
-    end
 
-    artefacts = sorted_artefacts_for_tag_ids(
-      requested_tags.map(&:tag_id),
+    artefacts = sorted_artefacts_for_tag_id(
+      tag_id,
       params[:sort]
     )
     results = map_artefacts_and_add_editions(artefacts)
@@ -421,16 +410,9 @@ class GovUkContentApi < Sinatra::Application
     end
   end
 
-  def include_children(tags)
-    # Given a list of tags, return a list of those tags and their children
-    child_tags = Tag.any_in(parent_id: tags.map(&:tag_id))
-    # TODO: remove duplicates?
-    tags + child_tags
-  end
-
-  def sorted_artefacts_for_tag_ids(tag_ids, sort)
-    statsd.time("#{@statsd_scope}.multi.#{tag_ids.length}") do
-      artefacts = Artefact.live.any_in(tag_ids: tag_ids)
+  def sorted_artefacts_for_tag_id(tag_id, sort)
+    statsd.time("#{@statsd_scope}.#{tag_id}") do
+      artefacts = Artefact.live.where(tag_ids: tag_id)
 
       # Load in the curated list and use it as an ordering for the top items in
       # the list. Any artefacts not present in the list go on the end, in
@@ -456,7 +438,7 @@ class GovUkContentApi < Sinatra::Application
       # list is empty
 
       if sort == "curated"
-        curated_list = CuratedList.any_in(tag_ids: [tag_ids.first]).first
+        curated_list = CuratedList.where(tag_ids: [tag_id]).first
         first_ids = curated_list ? curated_list.artefact_ids : []
       else
         # Just fall back on alphabetical order

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -261,9 +261,6 @@ class GovUkContentApi < Sinatra::Application
       # If we can unambiguously determine the tag, redirect to its correct URL
       possible_tags = Tag.where(tag_id: params[:tag]).to_a
       if possible_tags.count == 1
-        # Convert the modifier keys to strings first, because otherwise they
-        # don't work with Hash#slice in the way you might expect, as the
-        # keys in `params` are actually strings
         modifier_params = params.slice('sort')
         redirect with_tag_url(possible_tags, modifier_params)
       else

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -250,8 +250,6 @@ class GovUkContentApi < Sinatra::Application
 
     @statsd_scope = 'request.with_tag'
 
-    modifiers = %w(sort)
-
     unless params[:tag].blank?
       # Old-style tag URLs without types specified
 
@@ -266,7 +264,7 @@ class GovUkContentApi < Sinatra::Application
         # Convert the modifier keys to strings first, because otherwise they
         # don't work with Hash#slice in the way you might expect, as the
         # keys in `params` are actually strings
-        modifier_params = params.slice(*modifiers)
+        modifier_params = params.slice('sort')
         redirect with_tag_url(possible_tags, modifier_params)
       else
         custom_404

--- a/test/requests/artefact_with_tags_request_test.rb
+++ b/test/requests/artefact_with_tags_request_test.rb
@@ -67,16 +67,6 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
       )
     end
 
-    it "should preserve the include_children options when redirecting" do
-      batman = FactoryGirl.create(:tag, tag_id: 'batman', title: 'Batman', tag_type: 'section')
-      get "/with_tag.json?tag=batman&include_children=1"
-      assert last_response.redirect?
-      assert_equal(
-        "http://example.org/with_tag.json?section=batman&include_children=1",
-        last_response.location
-      )
-    end
-
     it "should not allow filtering by multiple tags" do
       farmers = FactoryGirl.create(:tag, tag_id: 'crime', title: 'Crime', tag_type: 'section')
       business = FactoryGirl.create(:tag, tag_id: 'business', title: 'Business', tag_type: 'section')
@@ -150,39 +140,6 @@ class ArtefactWithTagsRequestTest < GovUkContentApiTest
 
         assert last_response.ok?, "request failed: #{last_response.status}"
         assert_equal 0, JSON.parse(last_response.body)["results"].count
-      end
-
-      describe "including chiuldren in results" do
-        before :each do
-          @foo = FactoryGirl.create(:tag, tag_id: 'foo', title: 'Business', tag_type: 'section', parent_id: "business")
-          @bar = FactoryGirl.create(:tag, tag_id: 'bar', title: 'Bar', tag_type: 'section', parent_id: nil)
-          @business_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['business'], state: 'live')
-          @foo_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['foo'], state: 'live')
-          @bar_artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", sections: ['bar'], state: 'live')
-        end
-
-        it "should not include any children by default" do
-          get "/with_tag.json?section=business"
-
-          assert last_response.ok?
-          parsed_response = JSON.parse(last_response.body)
-          assert_equal 1, parsed_response["results"].count
-          assert_equal "http://example.org/#{@business_artefact.slug}.json", parsed_response["results"][0]["id"]
-        end
-
-        it "should return include children in array of results" do
-          get "/with_tag.json?section=business&include_children=1"
-
-          assert last_response.ok?
-          assert_equal 2, JSON.parse(last_response.body)["results"].count
-        end
-
-        it "should return 501 if more than 1 child requested" do
-          get "/with_tag.json?section=business&include_children=2"
-
-          assert_equal 501, last_response.status
-          assert_status_field "Include children only supports a depth of 1.", last_response
-        end
       end
     end
 


### PR DESCRIPTION
This was used in an early version of the browse pages (when they were single pages that were JS driven).  It's no longer used anywhere, so best removed to reduce complexity.
