### PR TITLE
Enable Rabl template source caching

### DIFF
--- a/config/rabl.rb
+++ b/config/rabl.rb
@@ -10,4 +10,9 @@ Rabl.configure do |config|
   # '{"tag": { ... }' block.
   config.include_json_root = false
   config.include_child_root = false
+
+  # Cache template source (i.e. only read once off disk) in non-development
+  # environments. You can also explicitly set RABL_CACHE=1 to turn on template
+  # source caching.
+  config.cache_sources = ENV['RABL_CACHE'] || ENV['RACK_ENV'] != 'development'
 end


### PR DESCRIPTION
Some profiling of the Rabl views showed that Rabl was spending inordinate
amounts of time hitting the filesystem. Enabling Rabl template caching results
in an immediate 2X speedup.

See call graph before: http://i.imgur.com/XtYpBNF.gif

And after: http://i.imgur.com/zyqUy8M.gif

And average response time before:

```
$ wrk -c1 -t1 -d30s http://contentapi.dev.gov.uk/tags.json
Running 30s test @ http://contentapi.dev.gov.uk/tags.json
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   354.58ms   39.16ms 380.93ms   99.00%
    Req/Sec     0.00      0.00     0.00    100.00%
  83 requests in 30.00s, 7.57MB read
Requests/sec:      2.77
Transfer/sec:    258.26KB
```

And after:

```
$ wrk -c1 -t1 -d30s http://contentapi.dev.gov.uk/tags.json
Running 30s test @ http://contentapi.dev.gov.uk/tags.json
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   196.28ms   27.24ms 339.56ms   96.48%
    Req/Sec     0.00      0.00     0.00    100.00%
  149 requests in 30.01s, 13.58MB read
Requests/sec:      4.97
Transfer/sec:    463.56KB
```
