### PR TITLE
Fix bug when requesting non-existent edition

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -486,6 +486,9 @@ class GovUkContentApi < Sinatra::Application
       end
     end
 
+    if version_number && artefact.edition.nil?
+      custom_404
+    end
     if artefact.edition && version_number.nil?
       if artefact.edition.state == 'archived'
         custom_410

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -354,6 +354,14 @@ class ArtefactRequestTest < GovUkContentApiTest
           assert_equal 200, last_response.status
           JSON.parse(last_response.body)
         end
+
+        it "should 404 if a non-existent edition is requested" do
+          Warden::Proxy.any_instance.expects(:authenticate?).returns(true)
+          Warden::Proxy.any_instance.expects(:user).returns(ReadOnlyUser.new("permissions" => ["access_unpublished"]))
+
+          get "/#{@artefact.slug}.json?edition=3", {}, bearer_token_for_user_with_permission
+          assert_equal 404, last_response.status
+        end
       end
     end
 


### PR DESCRIPTION
Currently content_api errors if private-frontend requests an edition
that doesn't exist for a given artefact.
