### PR TITLE
Fix Israel naming

### DIFF
--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -195,7 +195,7 @@
   slug: iraq
 - name: Ireland
   slug: ireland
-- name: Israel and the Occupied Palestinian Territories
+- name: Israel
   slug: israel
 - name: Italy
   slug: italy


### PR DESCRIPTION
Israel was temporarily renamed to "Israel and the Occupied Palestinian Terroritories" before launch as that was how the content was written.

This change reverts that as the content is now going to be split into 2.

This is to be deployed tomorrow (Tuesday) morning.
