### PR TITLE
Pull in fact values in markdown fields.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'gds-sso', '3.0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '5.3.0'
+  gem 'gds-api-adapters', '7.2.0'
 end
 
 gem 'govspeak', '1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    gds-api-adapters (5.3.0)
+    gds-api-adapters (7.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -98,7 +98,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.1)
-    mime-types (1.19)
+    mime-types (1.23)
     minitest (3.4.0)
     mocha (0.12.4)
       metaclass (~> 0.0.1)
@@ -225,7 +225,7 @@ DEPENDENCIES
   ci_reporter (= 1.7.0)
   database_cleaner (= 0.7.2)
   factory_girl (= 3.6.1)
-  gds-api-adapters (= 5.3.0)
+  gds-api-adapters (= 7.2.0)
   gds-sso (= 3.0.1)
   govspeak (= 1.0.1)
   govuk_content_models (= 5.0.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -100,7 +100,7 @@ class GovUkContentApi < Sinatra::Application
       end
 
       render :rabl, :search, format: "json"
-    rescue GdsApi::Rummager::SearchServiceError, GdsApi::Rummager::SearchTimeout
+    rescue GdsApi::HTTPErrorResponse, GdsApi::TimedOutException
       statsd.increment('request.search.unavailable')
       halt 503, render(:rabl, :unavailable, format: "json")
     end

--- a/lib/content_format_helpers.rb
+++ b/lib/content_format_helpers.rb
@@ -1,9 +1,9 @@
 
 # This has an implicit requirement on GdsApi::Helpers being included.
-# They App includes them before this class.
+# The App includes them before this class.
 module ContentFormatHelpers
 
-  EMBEDDED_FACT_REGEXP = /\[fact\:([a-z0-9-]+)\]/i
+  EMBEDDED_FACT_REGEXP = /\[fact\:([a-z0-9-]+)\]/i # e.g. [fact:vat-rates]
 
   def process_content(string)
     unless params[:content_format] == "govspeak"

--- a/lib/content_format_helpers.rb
+++ b/lib/content_format_helpers.rb
@@ -1,8 +1,29 @@
+require 'gds_api/fact_cave'
+
 module ContentFormatHelpers
-  def format_content(string)
-    if params[:content_format] == "govspeak"
-      return string
+
+  EMBEDDED_FACT_REGEXP = /\[Fact\:([\w-]+)\]/
+
+  def process_content(string)
+    unless params[:content_format] == "govspeak"
+      string = Govspeak::Document.new(string, auto_ids: false).to_html
     end
-    Govspeak::Document.new(string, auto_ids: false).to_html
+    interpolate_fact_values(string)
+  end
+
+private
+
+  def interpolate_fact_values(string)
+    string.gsub(EMBEDDED_FACT_REGEXP) do |match|
+      if fact = fact_cave.fact($1)
+        fact.details.value
+      else
+        ''
+      end
+    end
+  end
+
+  def fact_cave
+    GdsApi::FactCave.new(Plek.current.find('fact-cave'))
   end
 end

--- a/lib/content_format_helpers.rb
+++ b/lib/content_format_helpers.rb
@@ -1,8 +1,9 @@
-require 'gds_api/fact_cave'
 
+# This has an implicit requirement on GdsApi::Helpers being included.
+# They App includes them before this class.
 module ContentFormatHelpers
 
-  EMBEDDED_FACT_REGEXP = /\[Fact\:([\w-]+)\]/
+  EMBEDDED_FACT_REGEXP = /\[fact\:([a-z0-9-]+)\]/i
 
   def process_content(string)
     unless params[:content_format] == "govspeak"
@@ -15,15 +16,11 @@ private
 
   def interpolate_fact_values(string)
     string.gsub(EMBEDDED_FACT_REGEXP) do |match|
-      if fact = fact_cave.fact($1)
+      if fact = fact_cave_api.fact($1)
         fact.details.value
       else
         ''
       end
     end
-  end
-
-  def fact_cave
-    GdsApi::FactCave.new(Plek.current.find('fact-cave'))
   end
 end

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 require 'uri'
+require 'gds_api/test_helpers/fact_cave'
 
 class ArtefactRequestTest < GovUkContentApiTest
+  include GdsApi::TestHelpers::FactCave
+
   def bearer_token_for_user_with_permission
     { 'HTTP_AUTHORIZATION' => 'Bearer xyz_has_permission_xyz' }
   end
@@ -405,36 +408,93 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal "edition title", parsed_response["title"]
     end
 
-    it "should convert artefact body and part bodies to html" do
-      artefact = FactoryGirl.create(:artefact, slug: "annoying", state: 'live')
-      FactoryGirl.create(:guide_edition,
-          panopticon_id: artefact.id,
-          parts: [
-            Part.new(title: "Part One", body: "## Header 2", slug: "part-one")
-          ],
-          state: 'published')
+    describe "processing content" do
+      it "should convert artefact body and part bodies to html" do
+        artefact = FactoryGirl.create(:artefact, slug: "annoying", state: 'live')
+        FactoryGirl.create(:guide_edition,
+            panopticon_id: artefact.id,
+            parts: [
+              Part.new(title: "Part One", body: "## Header 2", slug: "part-one")
+            ],
+            state: 'published')
 
-      get "/#{artefact.slug}.json"
+        get "/#{artefact.slug}.json"
 
-      parsed_response = JSON.parse(last_response.body)
-      assert_equal 200, last_response.status
-      assert_equal "<h2>Header 2</h2>\n", parsed_response["details"]["parts"][0]["body"]
-    end
+        parsed_response = JSON.parse(last_response.body)
+        assert_equal 200, last_response.status
+        assert_equal "<h2>Header 2</h2>\n", parsed_response["details"]["parts"][0]["body"]
+      end
 
-    it "should return govspeak in artefact body and part bodies if requested" do
-      artefact = FactoryGirl.create(:artefact, slug: "annoying", state: 'live')
-      FactoryGirl.create(:guide_edition,
-          panopticon_id: artefact.id,
-          parts: [
-            Part.new(title: "Part One", body: "## Header 2", slug: "part-one")
-          ],
-          state: 'published')
+      it "should return govspeak in artefact body and part bodies if requested" do
+        artefact = FactoryGirl.create(:artefact, slug: "annoying", state: 'live')
+        FactoryGirl.create(:guide_edition,
+            panopticon_id: artefact.id,
+            parts: [
+              Part.new(title: "Part One", body: "## Header 2", slug: "part-one")
+            ],
+            state: 'published')
 
-      get "/#{artefact.slug}.json?content_format=govspeak"
+        get "/#{artefact.slug}.json?content_format=govspeak"
 
-      parsed_response = JSON.parse(last_response.body)
-      assert_equal 200, last_response.status
-      assert_equal "## Header 2", parsed_response["details"]["parts"][0]["body"]
+        parsed_response = JSON.parse(last_response.body)
+        assert_equal 200, last_response.status
+        assert_equal "## Header 2", parsed_response["details"]["parts"][0]["body"]
+      end
+
+      describe "interpolating fact values" do
+        it "should interploate fact values from the fact cave into the bodies" do
+          fact_cave_has_a_fact('vat-rate', '20')
+
+          artefact = FactoryGirl.create(:artefact, slug: "vat", state: 'live')
+          FactoryGirl.create(:guide_edition,
+              panopticon_id: artefact.id,
+              parts: [
+                Part.new(title: "Part One", body: "##The current VAT rate is [fact:vat-rate]%", slug: "part-one")
+              ],
+              state: 'published')
+
+          get "/#{artefact.slug}.json"
+
+          parsed_response = JSON.parse(last_response.body)
+          assert_equal 200, last_response.status
+          assert_equal "<h2>The current VAT rate is 20%</h2>", parsed_response["details"]["parts"][0]["body"].strip
+        end
+
+        it "should still interpolate fact values when govspeak requested" do
+          fact_cave_has_a_fact('vat-rate', '20')
+          artefact = FactoryGirl.create(:artefact, slug: "vat", state: 'live')
+          FactoryGirl.create(:guide_edition,
+              panopticon_id: artefact.id,
+              parts: [
+                Part.new(title: "Part One", body: "##The current VAT rate is [fact:vat-rate]%", slug: "part-one")
+              ],
+              state: 'published')
+
+          get "/#{artefact.slug}.json?content_format=govspeak"
+
+          parsed_response = JSON.parse(last_response.body)
+          assert_equal 200, last_response.status
+          assert_equal "##The current VAT rate is 20%", parsed_response["details"]["parts"][0]["body"]
+        end
+
+        it "should use a blank value if the fact cave 404's for a fact" do
+          fact_cave_does_not_have_a_fact('vat-rate')
+
+          artefact = FactoryGirl.create(:artefact, slug: "vat", state: 'live')
+          FactoryGirl.create(:guide_edition,
+              panopticon_id: artefact.id,
+              parts: [
+                Part.new(title: "Part One", body: "##The current VAT rate is [fact:vat-rate]%", slug: "part-one")
+              ],
+              state: 'published')
+
+          get "/#{artefact.slug}.json"
+
+          parsed_response = JSON.parse(last_response.body)
+          assert_equal 200, last_response.status
+          assert_equal "<h2>The current VAT rate is %</h2>", parsed_response["details"]["parts"][0]["body"].strip
+        end
+      end
     end
 
     it "should return parts in the correct order" do

--- a/test/requests/search_request_test.rb
+++ b/test/requests/search_request_test.rb
@@ -81,7 +81,7 @@ class SearchRequestTest < GovUkContentApiTest
   end
 
   it "should return 503 if connection times out" do
-    GdsApi::Rummager.any_instance.stubs(:search).raises(GdsApi::Rummager::SearchTimeout)
+    GdsApi::Rummager.any_instance.stubs(:search).raises(GdsApi::TimedOutException)
     get "/search.json?q=government"
 
     assert_equal 503, last_response.status

--- a/test/unit/content_format_helpers_test.rb
+++ b/test/unit/content_format_helpers_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "content_format_helpers"
+require "gds_api/test_helpers/fact_cave"
+require "mocha"
+
+class ContentFormatHelpersTest < MiniTest::Spec
+
+  include ContentFormatHelpers
+  include GdsApi::TestHelpers::FactCave
+
+  describe "process_content" do
+    it "should convert govspeak to html" do
+      self.stubs(:params).returns({})
+      assert_equal "<h1>GOVUK Govspeak</h1>\n\n<h2>Headings</h2>\n", process_content("# GOVUK Govspeak\n\n## Headings")
+    end
+
+    it "should return unformatted govspeak when requested" do
+      self.stubs(:params).returns({:content_format => 'govspeak'})
+      assert_equal "# GOVUK Govspeak\n\n## Headings", process_content("# GOVUK Govspeak\n\n## Headings")
+    end
+
+    it "should interpolate fact values into content when requested as govspeak" do
+      fact_cave_has_a_fact('vat-rate', {:id => 'vat-rate', :title => 'VAT rate', :details => { :value => '20%' }})
+      self.stubs(:params).returns({:content_format => 'govspeak'})
+      assert_equal "## The current VAT rate is 20%", process_content("## The current VAT rate is [Fact:vat-rate]")
+    end
+
+    it "should interpolate fact values into content and format govspeak" do
+      fact_cave_has_a_fact('vat-rate', {:id => 'vat-rate', :title => 'VAT rate', :details => { :value => '20%' }})
+      fact_cave_has_a_fact('pi-2-decimal-places',
+                           {:id => 'pi-2-decimal-places', :title => 'PI to 2 decimal places', :details => { :value => '3.14' }})
+      self.stubs(:params).returns({})
+      assert_equal "<p><em>The current VAT rate is 20%, PI is approx. 3.14</em></p>\n",
+        process_content("*The current VAT rate is [Fact:vat-rate], PI is approx. [Fact:pi-2-decimal-places]*")
+    end
+
+    it "should replace fact content markers with an empty string where no value exists" do
+      fact_cave_does_not_have_a_fact('foo')
+      self.stubs(:params).returns({})
+      assert_equal "<p>The value of foo is </p>\n", process_content("The value of foo is [Fact:foo]")
+    end
+  end
+end

--- a/test/unit/content_format_helpers_test.rb
+++ b/test/unit/content_format_helpers_test.rb
@@ -1,43 +1,49 @@
 require "test_helper"
 require "content_format_helpers"
+require "gds_api/helpers"
 require "gds_api/test_helpers/fact_cave"
 require "mocha"
 
-class ContentFormatHelpersTest < MiniTest::Spec
+describe ContentFormatHelpers do
 
-  include ContentFormatHelpers
+  class ContentFormatIncluder
+    include GdsApi::Helpers
+    include ContentFormatHelpers
+  end
+
   include GdsApi::TestHelpers::FactCave
 
   describe "process_content" do
+    before :each do
+      @helper = ContentFormatIncluder.new
+      @helper.stubs(:params).returns({})
+    end
+
     it "should convert govspeak to html" do
-      self.stubs(:params).returns({})
-      assert_equal "<h1>GOVUK Govspeak</h1>\n\n<h2>Headings</h2>\n", process_content("# GOVUK Govspeak\n\n## Headings")
+      assert_equal "<h1>GOVUK Govspeak</h1>\n\n<h2>Headings</h2>\n", @helper.process_content("# GOVUK Govspeak\n\n## Headings")
     end
 
     it "should return unformatted govspeak when requested" do
-      self.stubs(:params).returns({:content_format => 'govspeak'})
-      assert_equal "# GOVUK Govspeak\n\n## Headings", process_content("# GOVUK Govspeak\n\n## Headings")
+      @helper.stubs(:params).returns({:content_format => 'govspeak'})
+      assert_equal "# GOVUK Govspeak\n\n## Headings", @helper.process_content("# GOVUK Govspeak\n\n## Headings")
     end
 
     it "should interpolate fact values into content when requested as govspeak" do
-      fact_cave_has_a_fact('vat-rate', {:id => 'vat-rate', :title => 'VAT rate', :details => { :value => '20%' }})
-      self.stubs(:params).returns({:content_format => 'govspeak'})
-      assert_equal "## The current VAT rate is 20%", process_content("## The current VAT rate is [Fact:vat-rate]")
+      fact_cave_has_a_fact('vat-rate', '20%')
+      @helper.stubs(:params).returns({:content_format => 'govspeak'})
+      assert_equal "## The current VAT rate is 20%", @helper.process_content("## The current VAT rate is [fact:vat-rate]")
     end
 
     it "should interpolate fact values into content and format govspeak" do
-      fact_cave_has_a_fact('vat-rate', {:id => 'vat-rate', :title => 'VAT rate', :details => { :value => '20%' }})
-      fact_cave_has_a_fact('pi-2-decimal-places',
-                           {:id => 'pi-2-decimal-places', :title => 'PI to 2 decimal places', :details => { :value => '3.14' }})
-      self.stubs(:params).returns({})
+      fact_cave_has_a_fact('vat-rate', '20%')
+      fact_cave_has_a_fact('pi-2-decimal-places', '3.14')
       assert_equal "<p><em>The current VAT rate is 20%, PI is approx. 3.14</em></p>\n",
-        process_content("*The current VAT rate is [Fact:vat-rate], PI is approx. [Fact:pi-2-decimal-places]*")
+        @helper.process_content("*The current VAT rate is [Fact:vat-rate], PI is approx. [Fact:pi-2-decimal-places]*")
     end
 
     it "should replace fact content markers with an empty string where no value exists" do
       fact_cave_does_not_have_a_fact('foo')
-      self.stubs(:params).returns({})
-      assert_equal "<p>The value of foo is </p>\n", process_content("The value of foo is [Fact:foo]")
+      assert_equal "<p>The value of foo is </p>\n", @helper.process_content("The value of foo is [Fact:foo]")
     end
   end
 end

--- a/views/_fields.rabl
+++ b/views/_fields.rabl
@@ -13,7 +13,7 @@ node(:need_extended_font) { |artefact| artefact.need_extended_font }
     :change_description, :reviewed_at].each do |field|
   node(field, :if => lambda { |artefact| artefact.edition.respond_to?(field) }) do |artefact|
     if artefact.edition.class::GOVSPEAK_FIELDS.include?(field)
-      format_content(artefact.edition.send(field))
+      process_content(artefact.edition.send(field))
     else
       artefact.edition.send(field)
     end

--- a/views/_parts.rabl
+++ b/views/_parts.rabl
@@ -6,7 +6,7 @@ node do |artefact|
               slug: p.slug,
               order: p.order,
               title: p.title,
-              body: format_content(p.body)
+              body: process_content(p.body)
             }
     list_parts.push(part)
   end


### PR DESCRIPTION
This adds functionality to pull in fact values from the Fact Cave and insert them into the content of govspeak fields.

This required bumping api adapters, which in turn required updating the exception handling in the /search.json endpoint.
