### PR TITLE
Bump content models to 5.5.1 to fix a bug.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'omniauth-gds', '0.0.3' #rubygems doesn't seem to pull this in transitively
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '5.5.0'
+  gem 'govuk_content_models', '5.5.1'
 end
 
 gem 'gds-sso', '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.5.0)
+    govuk_content_models (5.5.1)
       bson_ext
       differ
       gds-api-adapters
@@ -228,7 +228,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.2.0)
   gds-sso (= 3.0.1)
   govspeak (= 1.0.1)
-  govuk_content_models (= 5.5.0)
+  govuk_content_models (= 5.5.1)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)


### PR DESCRIPTION
There was a missing `require` in one of the models, which would sometimes cause tests to fail, depending on the order things had been loaded.
