### PR TITLE
Better dev reloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,5 @@ end
 
 group :development do
   # (Intelligent) reloading server in development
-  gem "mr-sparkle", "0.1.0", git: "https://github.com/alphagov/mr-sparkle.git", branch: "optional_force_polling", ref: "8dfecf6"
+  gem "mr-sparkle", "0.2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/mr-sparkle.git
-  revision: 8dfecf6034dfe6f751f6597b7feeb3d423e8503c
-  ref: 8dfecf6
-  branch: optional_force_polling
-  specs:
-    mr-sparkle (0.1.0)
-      listen (~> 1.0)
-      rb-fsevent (>= 0.9)
-      rb-inotify (>= 0.8)
-      unicorn (>= 4.5)
-
 GEM
   remote: https://rubygems.org/
   remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
@@ -123,6 +111,11 @@ GEM
       activemodel (~> 3.1)
       mongo (<= 1.6.2)
       tzinfo (~> 0.3.22)
+    mr-sparkle (0.2.0)
+      listen (~> 1.0)
+      rb-fsevent (>= 0.9)
+      rb-inotify (>= 0.8)
+      unicorn (>= 4.5)
     multi_json (1.3.7)
     multipart-post (1.1.5)
     nokogiri (1.5.5)
@@ -248,7 +241,7 @@ DEPENDENCIES
   minitest (= 3.4.0)
   mocha (= 0.12.4)
   mongo (>= 1.6.2)
-  mr-sparkle (= 0.1.0)!
+  mr-sparkle (= 0.2.0)
   omniauth-gds (= 0.0.3)
   plek (= 1.3.1)
   rabl (= 0.6.14)


### PR DESCRIPTION
Twin of https://github.com/alphagov/rummager/pull/138

Try it out with: 

``` bash
bundle exec mr-sparkle --force-polling -- -p 3022
```

Though if you want it to reload on changes to `rabl` files, you'll need something like:

``` bash
bundle exec mr-sparkle --force-polling --pattern "rabl|rb|ru|txt|yml" -- -p 3022
```

I'll add this latter form to https://github.gds/gds/development/blob/master/Procfile#L20
