### PR TITLE
Gracefully handle the q param being empty

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -93,6 +93,10 @@ class GovUkContentApi < Sinatra::Application
         custom_404
       end
 
+      if params[:q].nil? || params[:q].strip.empty?
+        custom_error(422, "Non-empty querystring is required in the 'q' parameter")
+      end
+
       statsd.time(@statsd_scope) do
         search_uri = Plek.current.find('search') + "/#{search_index}"
         client = GdsApi::Rummager.new(search_uri)

--- a/test/requests/search_request_test.rb
+++ b/test/requests/search_request_test.rb
@@ -57,6 +57,16 @@ class SearchRequestTest < GovUkContentApiTest
     assert_equal 0, parsed_response["total"]
   end
 
+  it "should return a semantic error if missing query" do
+    GdsApi::Rummager.any_instance.expects(:search).never
+
+    get "/search.json?q=++"
+    parsed_response = JSON.parse(last_response.body)
+
+    assert_equal 422, last_response.status
+    assert_equal "Non-empty querystring is required in the 'q' parameter", parsed_response["_response_info"]["status"]
+  end
+
   it "should default to the mainstream index" do
     search_stub = stub(search: { "results" => sample_results })
     GdsApi::Rummager.expects(:new).with { |u| u.match /mainstream/ }.returns(search_stub)


### PR DESCRIPTION
Until recently we could rely on gds-api-adapters, which would return an empty
array if the query was blank. Now though, we are expecting a Hash, so we get an
errror.

With this change we check the param ourself and reply accordingly.
