### PR TITLE
Remove unnecessary search params

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -100,7 +100,7 @@ class GovUkContentApi < Sinatra::Application
       statsd.time(@statsd_scope) do
         search_uri = Plek.current.find('search') + "/#{search_index}"
         client = GdsApi::Rummager.new(search_uri)
-        @results = client.search(params[:q], response_style: "hash")["results"]
+        @results = client.search(params[:q])["results"]
       end
 
       render :rabl, :search, format: "json"


### PR DESCRIPTION
These things are now the default, since:
https://github.com/alphagov/rummager/commit/1b0ab48073f758eb914c82471edee95c7e0477f2
