### PR TITLE
Limit fields from MongoDB for the artefact list.

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -422,7 +422,7 @@ class GovUkContentApi < Sinatra::Application
     expires DEFAULT_CACHE_TIME
 
     artefacts = statsd.time("request.artefacts") do
-      Artefact.live
+      Artefact.live.only(MinimalArtefactPresenter::REQUIRED_FIELDS)
     end
 
     if settings.pagination

--- a/lib/presenters/minimal_artefact_presenter.rb
+++ b/lib/presenters/minimal_artefact_presenter.rb
@@ -4,6 +4,8 @@
 # in the artefact list where we don't want to look up any extra information
 # across collections.
 class MinimalArtefactPresenter
+  REQUIRED_FIELDS = [:name, :kind, :slug]
+
   def initialize(artefact, url_helper)
     @artefact = artefact
     @url_helper = url_helper


### PR DESCRIPTION
When we're loading all the artefacts in one go, limiting the fields reduces the amount of memory we're using and makes the garbage collector's life easier.
