### PR TITLE
Make unencoded slashes work when requesting a tag

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -308,13 +308,13 @@ class GovUkContentApi < Sinatra::Application
     presenter.present.to_json
   end
 
-  get "/tags/:tag_type/:tag_id.json" do
+  get "/tags/:tag_type/*.json" do |tag_type, tag_id|
     set_expiry
 
-    tag_type = known_tag_types.from_plural(params[:tag_type])
+    tag_type = known_tag_types.from_plural(tag_type)
     custom_404 unless tag_type
 
-    @tag = Tag.by_tag_id(params[:tag_id], tag_type.singular)
+    @tag = Tag.by_tag_id(tag_id, tag_type.singular)
     if @tag
       tag_presenter = TagPresenter.new(@tag, url_helper)
       SingleResultPresenter.new(tag_presenter).present.to_json

--- a/test/requests/tag_request_test.rb
+++ b/test/requests/tag_request_test.rb
@@ -54,7 +54,19 @@ class TagRequestTest < GovUkContentApiTest
       assert_equal nil, response['parent']
     end
 
-    it "should load a tag that includes a slash" do
+    it "should load a tag with a unencoded slash character in the tag ID" do
+      FactoryGirl.create(:tag, tag_id: 'crime/batman')
+
+      get "/tags/sections/crime/batman.json"
+      assert last_response.ok?
+      assert_status_field "ok", last_response
+      assert_equal(
+        "http://example.org/tags/sections/crime%2Fbatman.json",
+        JSON.parse(last_response.body)["id"]
+      )
+    end
+
+    it "should work with % encoded tag IDs" do
       FactoryGirl.create(:tag, tag_id: 'crime/batman')
 
       get "/tags/sections/crime%2Fbatman.json"


### PR DESCRIPTION
Right now, using an unencoded slash character in a URL for a tag ID returns a 404 for the tag, because Sinatra can't correctly match the route. Using`%2F` works, but this gets clobbered by Nginx when you make a request through www.gov.uk.

This changes the route to use a wildcard match, handling the parameters as block arguments instead of using the `params` hash.
