### PR TITLE
Fix constant assignment warnings in test runs

### DIFF
--- a/test/unit/url_helper_test.rb
+++ b/test/unit/url_helper_test.rb
@@ -2,9 +2,7 @@ require "test_helper"
 require "url_helper"
 
 describe URLHelper do
-  before do
-    DummyTag = Struct.new(:tag_id, :tag_type)
-  end
+  DummyTag = Struct.new(:tag_id, :tag_type)
 
   it "should use the app's `url` method when there is no prefix" do
     mock_app = mock("app") do


### PR DESCRIPTION
Because these tests reassigned the `DummyTag` constant before each test, the test run spat out these warnings:

```
test/unit/url_helper_test.rb:6: warning: already initialized constant DummyTag
```
