### PR TITLE
Sort artefacts for a tag in a case-insensitive order

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -630,7 +630,7 @@ class GovUkContentApi < Sinatra::Application
       return artefacts.to_a.sort_by { |artefact|
         [
           first_ids.find_index(artefact._id) || first_ids.length,
-          artefact.name
+          artefact.name.downcase
         ]
       }
     end

--- a/test/requests/curated_list_ordering_test.rb
+++ b/test/requests/curated_list_ordering_test.rb
@@ -128,6 +128,29 @@ class CuratedListOrderingTest < GovUkContentApiTest
     assert_result_titles ["Bat 3", "Bat", "Bat 2"]
   end
 
+  it "should sort mixed case artefact titles indifferently" do
+    artefacts = [
+      ["superman", "Superman"],
+      ["lex-luthor", "lex luthor"],
+      ["bizarro", "bizarro"]
+    ]
+
+    FactoryGirl.create(:tag, tag_id: "superman", title: "Superman", tag_type: "section")
+    artefacts.each { |slug, name|
+      FactoryGirl.create(
+        :artefact,
+        owning_app: "custom-application",
+        section_ids: ["superman"],
+        name: name,
+        slug: slug,
+        state: "live"
+      )
+    }
+    get "/with_tag.json?section=superman&sort=curated"
+
+    assert_result_titles ["bizarro", "lex luthor", "Superman"]
+  end
+
   it "should exclude items not in the section" do
     curated_list = FactoryGirl.create(
       :curated_list,


### PR DESCRIPTION
Ruby's `sort_by` is case-sensitive, so a typical result would sort all the artefacts with initial uppercase characters higher than those without.

This isn't a case often seen in Mainstream content, but it's a common problem with detailed guides with a subject prefix (eg. "Oil and gas: access to data" vs "Oil and gas: DECC Public Register")
