### PR TITLE
Return an empty array for consistent behaviour with AR:Base#where

### DIFF
--- a/lib/read_only_user.rb
+++ b/lib/read_only_user.rb
@@ -12,7 +12,7 @@ class ReadOnlyUser < OpenStruct
 
   # For compatibility with https://github.com/alphagov/gds-sso/commit/9f2ae189117eca1758dea108923d15c6fe2b7de7
   def self.where(uid)
-    nil
+    []
   end
 
   def self.create!(auth_hash, options={})


### PR DESCRIPTION
For compatibility with https://github.com/alphagov/gds-sso/commit/9f2ae189117eca1758dea108923d15c6fe2b7de7
