### PR TITLE
Present specialist documents in API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '6.1.0'
+  gem 'govuk_content_models', '7.0.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (6.1.0)
+    govuk_content_models (7.0.0)
       bson_ext
       differ
       gds-api-adapters
@@ -236,7 +236,7 @@ DEPENDENCIES
   gds-api-adapters (= 8.2.1)
   gds-sso (= 9.2.0)
   govspeak (= 1.0.1)
-  govuk_content_models (= 6.1.0)
+  govuk_content_models (= 7.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -25,6 +25,7 @@ require "presenters/travel_advice_index_presenter"
 require "presenters/business_support_scheme_presenter"
 require "presenters/licence_presenter"
 require "presenters/tagged_artefact_presenter"
+require "presenters/specialist_document_presenter"
 require "govspeak_formatter"
 
 # Note: the artefact patch needs to be included before the Kaminari patch,
@@ -535,6 +536,9 @@ class GovUkContentApi < Sinatra::Application
       attach_publisher_edition(@artefact, params[:edition])
     elsif @artefact.kind == 'travel-advice'
       attach_travel_advice_country_and_edition(@artefact, params[:edition])
+    elsif @artefact.kind == 'specialist-document'
+      @artefact.edition = SpecialistDocumentEdition.where(panopticon_id: @artefact.id, state: 'published').first
+      custom_404 unless @artefact.edition
     end
 
     presenter = SingleResultPresenter.new(

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -46,6 +46,12 @@ class ArtefactPresenter
     video_summary
     video_url
     will_continue_on
+    opened_date
+    closed_date
+    case_type
+    case_state
+    market_sector
+    outcome_type
   ).map(&:to_sym)
 
   def initialize(artefact, url_helper, govspeak_formatter)

--- a/lib/presenters/specialist_document_presenter.rb
+++ b/lib/presenters/specialist_document_presenter.rb
@@ -1,0 +1,12 @@
+class SpecialistDocumentPresenter
+  def initialize(artefact, url_helper)
+    @artefact = artefact
+    @url_helper = url_helper
+  end
+
+  def present
+    MinimalArtefactPresenter.new(@artefact, @url_helper).present.merge(
+      'summary' => @artefact.edition.summary
+    )
+  end
+end

--- a/test/requests/specialist_document_test.rb
+++ b/test/requests/specialist_document_test.rb
@@ -1,0 +1,91 @@
+require_relative '../test_helper'
+require 'gds_api/test_helpers/asset_manager'
+
+class SpecialistDocumentTest < GovUkContentApiTest
+  describe "loading a published specialist document" do
+    before :each do
+      @artefact = FactoryGirl.create(:artefact,
+        slug: "mhra-drug-alerts/private-healthcare-investigation",
+        state: "live",
+        kind: "specialist-document",
+        owning_app: "specialist-publisher",
+        name: "Private Healthcare Investigation"
+      )
+      @edition = FactoryGirl.create(:specialist_document_edition,
+        slug: "mhra-drug-alerts/private-healthcare-investigation",
+        title: "Private Healthcare Investigation",
+        summary: "This is the summary",
+        body: "This is the body",
+        state: "published",
+        opened_date: Date.parse("2013-03-21"),
+        closed_date: nil,
+        case_type: "market-investigation",
+        case_state: "open",
+        market_sector: "healthcare",
+        outcome_type: "referred",
+        panopticon_id: @artefact.id
+      )
+    end
+
+    it "should return a successful response" do
+      get '/mhra-drug-alerts/private-healthcare-investigation.json'
+      assert last_response.ok?
+    end
+
+    it "should return json containing the published edition" do
+      get '/mhra-drug-alerts/private-healthcare-investigation.json'
+      parsed_response = JSON.parse(last_response.body)
+
+      assert_base_artefact_fields(parsed_response)
+      assert_equal 'specialist_document', parsed_response["format"]
+      assert_equal 'Private Healthcare Investigation', parsed_response["title"]
+      assert_equal 'This is the summary', parsed_response["details"]["summary"]
+      assert_equal '2013-03-21', parsed_response["details"]["opened_date"]
+      assert_equal nil, parsed_response["details"]["closed_date"]
+      assert_equal "market-investigation", parsed_response["details"]["case_type"]
+      assert_equal "open", parsed_response["details"]["case_state"]
+      assert_equal "healthcare", parsed_response["details"]["market_sector"]
+      assert_equal "referred", parsed_response["details"]["outcome_type"]
+    end
+  end
+
+  describe "artefact but no edition" do
+    before do
+      FactoryGirl.create(:artefact,
+        slug: "mhra-drug-alerts/private-healthcare-investigation",
+        state: "live",
+        kind: "specialist-document",
+        owning_app: "specialist-publisher",
+        name: "Private Healthcare Investigation"
+      )
+    end
+
+    it "should return 404 response" do
+      get '/mhra-drug-alerts/private-healthcare-investigation.json'
+      assert last_response.not_found?
+    end
+  end
+
+  describe "artefact but no published edition" do
+    before do
+      @artefact = FactoryGirl.create(:artefact,
+        slug: "mhra-drug-alerts/private-healthcare-investigation",
+        state: "live",
+        kind: "specialist-document",
+        owning_app: "specialist-publisher",
+        name: "Private Healthcare Investigation"
+      )
+      @edition = FactoryGirl.create(:specialist_document_edition,
+        slug: "mhra-drug-alerts/private-healthcare-investigation",
+        title: "Private Healthcare Investigation",
+        state: "draft",
+        panopticon_id: @artefact.id
+      )
+    end
+
+    it "should return 404 response" do
+      get '/mhra-drug-alerts/private-healthcare-investigation.json'
+      assert last_response.not_found?
+    end
+  end
+end


### PR DESCRIPTION
This adds support for presenting specialist documents via the content API.

It only presents published documents at the moment, we'll be adding support for previewing drafts later.
