### PR TITLE
Fetch SpecialistDocumentEditions by slug not panopticon_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '7.2.0'
+  gem 'govuk_content_models', '7.3.1'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (7.2.0)
+    govuk_content_models (7.3.1)
       bson_ext
       differ
       gds-api-adapters
@@ -236,7 +236,7 @@ DEPENDENCIES
   gds-api-adapters (= 8.2.1)
   gds-sso (= 9.2.0)
   govspeak (= 1.0.1)
-  govuk_content_models (= 7.2.0)
+  govuk_content_models (= 7.3.1)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -560,7 +560,7 @@ class GovUkContentApi < Sinatra::Application
     elsif @artefact.kind == 'travel-advice'
       attach_travel_advice_country_and_edition(@artefact, params[:edition])
     elsif @artefact.kind == 'specialist-document'
-      @artefact.edition = SpecialistDocumentEdition.where(panopticon_id: @artefact.id, state: 'published').first
+      @artefact.edition = SpecialistDocumentEdition.where(slug: @artefact.slug, state: 'published').first
       custom_404 unless @artefact.edition
     end
 

--- a/test/requests/specialist_document_test.rb
+++ b/test/requests/specialist_document_test.rb
@@ -23,7 +23,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
         case_state: "open",
         market_sector: "healthcare",
         outcome_type: "referred",
-        panopticon_id: @artefact.id
+        document_id: "doesnt-matter-here"
       )
     end
 
@@ -79,7 +79,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
         slug: "mhra-drug-alerts/private-healthcare-investigation",
         title: "Private Healthcare Investigation",
         state: "draft",
-        panopticon_id: @artefact.id
+        document_id: "doesnt-matter-here"
       )
     end
 


### PR DESCRIPTION
Also bumped govuk_content_models to update SpecialistDocumentEdition.
It no longer requires panopticon_id.

Following on from https://github.com/alphagov/specialist-publisher/pull/22
