### PR TITLE
Return all published schemes by default

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -422,12 +422,13 @@ class GovUkContentApi < Sinatra::Application
         end
 
         if facets.empty?
-          editions = []
+          editions = BusinessSupportEdition.published
         else
-          editions = BusinessSupportEdition.for_facets(facets).published.
-            order_by([:priority, :desc], [:title, :asc])
+          editions = BusinessSupportEdition.for_facets(facets).published
         end
       end
+
+      editions = editions.order_by([:priority, :desc], [:title, :asc])
 
       @results = editions.map do |ed|
         artefact = Artefact.find(ed.panopticon_id)

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -145,18 +145,17 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       get "/business_support_schemes.json?identifiers=delta,wibble,fox-trot"
       assert_status_field "ok", last_response
       parsed_response = JSON.parse(last_response.body)
-
       assert_equal [], parsed_response["results"]
       assert_equal 0, parsed_response["total"]
     end
 
-    it "should return an empty result set with no query params" do
+    it "should return all results with no query params" do
       get "/business_support_schemes.json"
       assert_status_field "ok", last_response
       parsed_response = JSON.parse(last_response.body)
 
-      assert_equal [], parsed_response["results"]
-      assert_equal 0, parsed_response["total"]
+      assert_equal ["Bravo desc", "Alpha desc", "Charlie desc", "Echo desc"], parsed_response["results"].map { |s| s['short_description'] }
+      assert_equal 4, parsed_response["total"]
     end
 
     it "should order the results by priority and title" do


### PR DESCRIPTION
As part of [this story](https://www.pivotaltracker.com/story/show/65207124) business support scheme queries with no identifiers and no facet values should return all published schemes.
