### PR TITLE
Enable automatic header id generation for specialist documents

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -67,11 +67,11 @@ class GovUkContentApi < Sinatra::Application
     URLHelper.new(*parameters)
   end
 
-  def govspeak_formatter
+  def govspeak_formatter(options = {})
     if params[:content_format] == "govspeak"
-      GovspeakFormatter.new(:govspeak, fact_cave_api)
+      GovspeakFormatter.new(:govspeak, fact_cave_api, options)
     else
-      GovspeakFormatter.new(:html, fact_cave_api)
+      GovspeakFormatter.new(:html, fact_cave_api, options)
     end
   end
 
@@ -570,7 +570,7 @@ class GovUkContentApi < Sinatra::Application
     end
 
     presenter = SingleResultPresenter.new(
-      ArtefactPresenter.new(@artefact, url_helper, govspeak_formatter)
+      ArtefactPresenter.new(@artefact, url_helper, govspeak_formatter(auto_ids: @artefact.kind == 'specialist-document'))
     )
 
     presenter.present.to_json

--- a/lib/govspeak_formatter.rb
+++ b/lib/govspeak_formatter.rb
@@ -2,18 +2,19 @@ class GovspeakFormatter
 
   EMBEDDED_FACT_REGEXP = /\[fact\:([a-z0-9-]+)\]/i # e.g. [fact:vat-rates]
 
-  def initialize(format, fact_cave_api)
+  def initialize(format, fact_cave_api, options = {})
     unless [:html, :govspeak].include? format
       raise ArgumentError.new("Invalid format #{format}")
     end
 
     @format = format
     @fact_cave_api = fact_cave_api
+    @auto_ids = options.fetch(:auto_ids, false)
   end
 
   def format(govspeak_string)
     if @format == :html
-      formatted = Govspeak::Document.new(govspeak_string, auto_ids: false).to_html
+      formatted = Govspeak::Document.new(govspeak_string, auto_ids: @auto_ids).to_html
     else
       formatted = govspeak_string
     end

--- a/test/unit/govspeak_formatter_test.rb
+++ b/test/unit/govspeak_formatter_test.rb
@@ -23,6 +23,14 @@ describe GovspeakFormatter do
       )
     end
 
+    it "should add automatic header ids when requested" do
+      formatter = GovspeakFormatter.new(:html, empty_fact_cave, auto_ids: true)
+      assert_equal(
+        %Q{<h2 id="govspeak">Govspeak</h2>\n},
+        formatter.format("## Govspeak")
+      )
+    end
+
     it "should return unformatted govspeak when requested" do
       formatter = GovspeakFormatter.new(:govspeak, empty_fact_cave)
       assert_equal(


### PR DESCRIPTION
Specialist documents include a context menu which allows navigation
within the document on a single page. This relies on the headings having
id attributes.

https://www.pivotaltracker.com/story/show/65350948
