### PR TITLE
Remove business_support_identifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '8.9.0'
+  gem 'govuk_content_models', '9.0.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (8.9.0)
+    govuk_content_models (9.0.0)
       bson_ext
       differ
       gds-api-adapters
@@ -238,7 +238,7 @@ DEPENDENCIES
   gds-api-adapters (= 8.2.1)
   gds-sso (= 9.2.0)
   govspeak (= 1.5.1)
-  govuk_content_models (= 8.9.0)
+  govuk_content_models (= 9.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -412,20 +412,15 @@ class GovUkContentApi < Sinatra::Application
     set_expiry
 
     statsd.time("request.business_support_schemes") do
-      if params[:identifiers].present?
-        identifiers = params[:identifiers].to_s.split(",")
-        editions = BusinessSupportEdition.published.in(:business_support_identifier => identifiers)
-      else
-        facets = {}
-        [:business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
-          facets[key] = params[key] if params[key].present?
-        end
+      facets = {}
+      [:business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
+        facets[key] = params[key] if params[key].present?
+      end
 
-        if facets.empty?
-          editions = BusinessSupportEdition.published
-        else
-          editions = BusinessSupportEdition.for_facets(facets).published
-        end
+      if facets.empty?
+        editions = BusinessSupportEdition.published
+      else
+        editions = BusinessSupportEdition.for_facets(facets).published
       end
 
       editions = editions.order_by([:priority, :desc], [:title, :asc])

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -21,7 +21,6 @@ class ArtefactPresenter
     alternate_methods
     alternative_title
     body
-    business_support_identifier
     change_description
     continuation_link
     eligibility

--- a/lib/presenters/business_support_scheme_presenter.rb
+++ b/lib/presenters/business_support_scheme_presenter.rb
@@ -11,7 +11,6 @@ class BusinessSupportSchemePresenter
 
     base_presenter.present.merge({
       "short_description" => @artefact.edition.short_description,
-      "identifier" => @artefact.edition.business_support_identifier,
       "business_sizes" => @artefact.edition.business_sizes,
       "locations" => @artefact.edition.locations,
       "purposes" => @artefact.edition.purposes,

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -8,7 +8,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
   describe "finding business support editions" do
     before do
       @ed1 = FactoryGirl.create(:business_support_edition,
-                                :business_support_identifier => 'alpha',
                                 :priority => 1,
                                 :short_description => "Alpha desc",
                                 :business_sizes => ['up-to-249'],
@@ -16,21 +15,18 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
                                 :sectors => ['manufacturing','utilities'],
                                 :state => 'published')
       @ed2 = FactoryGirl.create(:business_support_edition,
-                                :business_support_identifier => 'beta',
                                 :priority => 2,
                                 :short_description => "Bravo desc",
                                 :business_sizes => ['up-to-249'],
                                 :locations => ['scotland', 'wales'],
                                 :state => 'published')
       @ed3 = FactoryGirl.create(:business_support_edition,
-                                :business_support_identifier => 'charlie',
                                 :priority => 1,
                                 :short_description => "Charlie desc",
                                 :business_sizes => ['up-to-1000'],
                                 :purposes => ['world-domination'],
                                 :state => 'published')
       @ed4 = FactoryGirl.create(:business_support_edition,
-                                :business_support_identifier => 'delta',
                                 :priority => 1,
                                 :short_description => "Delta desc",
                                 :locations => ['wales'],
@@ -38,7 +34,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
                                 :support_types => ['award','loan'],
                                 :state => 'in_review')
       @ed5 = FactoryGirl.create(:business_support_edition,
-                                :business_support_identifier => 'echo',
                                 :priority => 1,
                                 :short_description => "Echo desc",
                                 :business_sizes => ['up-to-249'],
@@ -60,32 +55,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       assert_equal ['Alpha desc', 'Bravo desc', 'Echo desc'], parsed_response["results"].map {|r| r["short_description"] }.sort
     end
 
-    it "should return basic artefact details for each result" do
-      get "/business_support_schemes.json?identifiers=alpha"
-      assert_status_field "ok", last_response
-      parsed_response = JSON.parse(last_response.body)
-
-      assert_equal 1, parsed_response["total"]
-
-      artefact = parsed_response["results"].first
-
-      assert_has_field artefact, 'title'
-      assert_has_field artefact, 'id'
-      assert_has_field artefact, 'web_url'
-      assert_has_field artefact, 'short_description'
-      assert_has_field artefact, 'format'
-      assert_has_field artefact, 'identifier'
-
-      assert_has_field artefact, 'business_sizes'
-      assert_has_field artefact, 'locations'
-      assert_has_field artefact, 'purposes'
-      assert_has_field artefact, 'sectors'
-      assert_has_field artefact, 'stages'
-      assert_has_field artefact, 'support_types'
-
-      assert_equal "Alpha desc", artefact["short_description"]
-    end
-
     it "should return basic artefact details for each result when queried by facets" do
       get "/business_support_schemes.json?locations=scotland&sectors=utilities"
       assert_status_field "ok", last_response
@@ -100,18 +69,8 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       assert_has_field artefact, 'web_url'
       assert_has_field artefact, 'short_description'
       assert_has_field artefact, 'format'
-      assert_has_field artefact, 'identifier'
 
       assert_equal "Alpha desc", artefact["short_description"]
-    end
-
-    it "should ignore identifiers with no matching business support edition" do
-      get "/business_support_schemes.json?identifiers=alpha,wibble,echo"
-      assert_status_field "ok", last_response
-      parsed_response = JSON.parse(last_response.body)
-
-      assert_equal 2, parsed_response["total"]
-      assert_equal ['Alpha desc', 'Echo desc'], parsed_response["results"].map {|r| r["short_description"].strip }.sort
     end
 
     it "should ignore invalid facet keys" do
@@ -123,15 +82,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       assert_equal ['Alpha desc', 'Bravo desc'], parsed_response["results"].map {|r| r["short_description"].strip }.sort
     end
 
-    it "should only return published business support editions" do
-      get "/business_support_schemes.json?identifiers=alpha,delta,echo,fox-trot"
-      assert_status_field "ok", last_response
-      parsed_response = JSON.parse(last_response.body)
-
-      assert_equal 2, parsed_response["total"]
-      assert_equal ['Alpha desc', 'Echo desc'], parsed_response["results"].map {|r| r["short_description"] }.sort
-    end
-
     it "should only return published business support editions when queried with facets" do
       get "/business_support_schemes.json?locations=scotland"
       assert_status_field "ok", last_response
@@ -139,14 +89,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
 
       assert_equal 2, parsed_response["total"]
       assert_equal ['Alpha desc', 'Bravo desc'], parsed_response["results"].map {|r| r["short_description"] }.sort
-    end
-
-    it "should return an empty result set if nothing matches" do
-      get "/business_support_schemes.json?identifiers=delta,wibble,fox-trot"
-      assert_status_field "ok", last_response
-      parsed_response = JSON.parse(last_response.body)
-      assert_equal [], parsed_response["results"]
-      assert_equal 0, parsed_response["total"]
     end
 
     it "should return all results with no query params" do

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -37,8 +37,8 @@ class FormatsRequestTest < GovUkContentApiTest
                                 body: "batman body", eligibility: "batman eligibility", evaluation: "batman evaluation",
                                 additional_information: "batman additional_information",
                                 min_value: 100, max_value: 1000, panopticon_id: artefact.id, state: 'published',
-                                business_support_identifier: 'enterprise-finance-guarantee', max_employees: 10,
-                                organiser: "Someone", continuation_link: "http://www.example.com/scheme", will_continue_on: "Example site")
+                                max_employees: 10, organiser: "Someone", continuation_link: "http://www.example.com/scheme",
+                                will_continue_on: "Example site")
     business_support.save!
 
     get '/batman.json'
@@ -50,10 +50,9 @@ class FormatsRequestTest < GovUkContentApiTest
     fields = parsed_response["details"]
     expected_fields = ['alternative_title', 'description', 'body',
                         'short_description', 'min_value', 'max_value', 'eligibility', 'evaluation', 'additional_information',
-                        'business_support_identifier', 'max_employees', 'organiser', 'continuation_link', 'will_continue_on']
+                        'max_employees', 'organiser', 'continuation_link', 'will_continue_on']
     assert_has_expected_fields(fields, expected_fields)
     assert_equal "No policeman is going to give the Batmobile a ticket", fields['short_description'].strip
-    assert_equal "enterprise-finance-guarantee", fields['business_support_identifier']
     assert_equal "No policeman is going to give the Batmobile a ticket", fields['short_description']
     assert_equal "<p>batman body</p>", fields['body'].strip
     assert_equal "<p>batman eligibility</p>", fields['eligibility'].strip


### PR DESCRIPTION
Business support finder and api applications no longer query business support data using the Imminence identifier.
Removes the corresponding references to business_support_identifier and updates content models to 9.0.0.
