### PR TITLE
An artefact can be associated to multiple need_ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'statsd-ruby', '1.0.0'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '9.0.0'
+  gem 'govuk_content_models', '10.2.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (9.0.0)
+    govuk_content_models (10.2.0)
       bson_ext
       differ
       gds-api-adapters
@@ -238,7 +238,7 @@ DEPENDENCIES
   gds-api-adapters (= 8.2.1)
   gds-sso (= 9.2.0)
   govspeak (= 1.5.1)
-  govuk_content_models (= 9.0.0)
+  govuk_content_models (= 10.2.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -486,9 +486,9 @@ class GovUkContentApi < Sinatra::Application
     set_expiry
 
     if check_unpublished_permission
-      artefacts = Artefact.where(need_id: id)
+      artefacts = Artefact.any_in(need_ids: [id])
     else
-      artefacts = Artefact.where(need_id: id, state: 'live')
+      artefacts = Artefact.live.any_in(need_ids: [id])
     end
 
     # This is copied and pasted from the /artefact.json method

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -12,7 +12,7 @@ require "presenters/local_authority_presenter"
 class ArtefactPresenter
 
   BASE_FIELDS = %w(
-    need_id business_proposition description language need_extended_font
+    need_ids business_proposition description language need_extended_font
   ).map(&:to_sym)
 
   OPTIONAL_FIELDS = %w(

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -444,7 +444,7 @@ class ArtefactRequestTest < GovUkContentApiTest
     end
 
     it "should return publication data if published" do
-      artefact = FactoryGirl.create(:artefact, business_proposition: true, need_id: 1234, state: 'live')
+      artefact = FactoryGirl.create(:artefact, business_proposition: true, need_ids: ['123412'], state: 'live')
       edition = FactoryGirl.create(:edition, panopticon_id: artefact.id, body: '# Important information', state: 'published')
 
       get "/#{artefact.slug}.json"
@@ -456,7 +456,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal "http://example.org/#{artefact.slug}.json", parsed_response["id"]
       assert_equal "#{public_web_url}/#{artefact.slug}", parsed_response["web_url"]
       assert_equal "<h1>Important information</h1>\n", parsed_response["details"]["body"]
-      assert_equal "1234", parsed_response["details"]["need_id"]
+      assert_equal ["123412"], parsed_response["details"]["need_ids"]
       assert_equal edition.updated_at.iso8601, parsed_response["updated_at"]
       # Temporarily included for legacy GA support. Will be replaced with "proposition" Tags
       assert_equal true, parsed_response["details"]["business_proposition"]

--- a/test/requests/needs_request_test.rb
+++ b/test/requests/needs_request_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 class NeedsRequestTest < GovUkContentApiTest
 
   def make_many_artefacts
-    FactoryGirl.create_list(:artefact, 25, :state => "live", :need_id => "Alpha")
+    FactoryGirl.create_list(:artefact, 25, :state => "live", :need_ids => ["100001"])
   end
 
   def bearer_token_for_user_with_permission
@@ -27,11 +27,11 @@ class NeedsRequestTest < GovUkContentApiTest
   end
 
   it "should return all artefacts that match a need" do
-    FactoryGirl.create(:artefact, :name => "Alpha1", :need_id => "Alpha", :state => 'live')
-    FactoryGirl.create(:artefact, :name => "Alpha2", :need_id => "Alpha", :state => 'live')
-    FactoryGirl.create(:artefact, :name => "Beta 1", :need_id => "Beta", :state => 'live')
+    FactoryGirl.create(:artefact, :name => "Alpha1", :need_ids => ["100001", "100003"], :state => 'live')
+    FactoryGirl.create(:artefact, :name => "Alpha2", :need_ids => ["100001"], :state => 'live')
+    FactoryGirl.create(:artefact, :name => "Beta 1", :need_ids => ["100002"], :state => 'live')
 
-    get "/for_need/Alpha.json"
+    get "/for_need/100001.json"
 
     assert_equal 200, last_response.status
     assert_status_field "ok", last_response
@@ -43,11 +43,11 @@ class NeedsRequestTest < GovUkContentApiTest
   end
 
   it "should only include live artefacts" do
-    FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Alpha", :state => 'draft')
-    FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Bravo", :state => 'live')
-    FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Charlie", :state => 'archived')
+    FactoryGirl.create(:artefact, :need_ids => ["100001", "100003"], :name => "Alpha", :state => 'draft')
+    FactoryGirl.create(:artefact, :need_ids => ["100001"], :name => "Bravo", :state => 'live')
+    FactoryGirl.create(:artefact, :need_ids => ["100001"], :name => "Charlie", :state => 'archived')
 
-    get "/for_need/Alpha.json"
+    get "/for_need/100001.json"
 
     assert_equal 200, last_response.status
     assert_status_field "ok", last_response
@@ -60,14 +60,14 @@ class NeedsRequestTest < GovUkContentApiTest
 
   describe "user has permission to view unpublished items" do
     it "should return draft data" do
-      FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Alpha", :state => 'draft')
-      FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Bravo", :state => 'live')
-      FactoryGirl.create(:artefact, :need_id => 'Alpha', :name => "Charlie", :state => 'archived')
+      FactoryGirl.create(:artefact, :need_ids => ["100001", "100003"], :name => "Alpha", :state => 'draft')
+      FactoryGirl.create(:artefact, :need_ids => ["100001"], :name => "Bravo", :state => 'live')
+      FactoryGirl.create(:artefact, :need_ids => ["100001"], :name => "Charlie", :state => 'archived')
 
       Warden::Proxy.any_instance.expects(:authenticate?).returns(true)
       Warden::Proxy.any_instance.expects(:user).returns(ReadOnlyUser.new("permissions" => ["access_unpublished"]))
 
-      get "/for_need/Alpha.json", {}, bearer_token_for_user_with_permission
+      get "/for_need/100001.json", {}, bearer_token_for_user_with_permission
       assert_equal 200, last_response.status
       parsed_response = JSON.parse(last_response.body)
 
@@ -85,7 +85,7 @@ class NeedsRequestTest < GovUkContentApiTest
 
     it "should paginate when there are enough matching needs" do
       make_many_artefacts
-      base_url = "/for_need/Alpha.json"
+      base_url = "/for_need/100001.json"
       get base_url
 
       assert last_response.ok?
@@ -100,7 +100,7 @@ class NeedsRequestTest < GovUkContentApiTest
 
     it "should display subsequent pages" do
       make_many_artefacts
-      base_url = "/for_need/Alpha.json"
+      base_url = "/for_need/100001.json"
 
       get "#{base_url}?page=3"
 
@@ -123,7 +123,7 @@ class NeedsRequestTest < GovUkContentApiTest
     it "should display large numbers of artefacts" do
       make_many_artefacts
 
-      get "/for_need/Alpha.json"
+      get "/for_need/100001.json"
 
       assert last_response.ok?
       parsed_response = JSON.parse(last_response.body)

--- a/test/requests/travel_advice_test.rb
+++ b/test/requests/travel_advice_test.rb
@@ -6,7 +6,7 @@ class TravelAdviceTest < GovUkContentApiTest
 
   describe "loading the travel-advice index artefact" do
     before do
-      @artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+      @artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                      :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend',
                                      :name => 'Foreign travel advice', :description => 'Oh I do want to live beside the seaside!')
     end
@@ -21,7 +21,7 @@ class TravelAdviceTest < GovUkContentApiTest
       assert_equal 'Foreign travel advice', parsed_response['title']
 
       details = parsed_response["details"]
-      expected_fields = ['description', 'need_id']
+      expected_fields = ['description', 'need_ids']
       assert_has_expected_fields(details, expected_fields)
       assert_equal 'Oh I do want to live beside the seaside!', details['description']
     end
@@ -166,7 +166,7 @@ class TravelAdviceTest < GovUkContentApiTest
           FactoryGirl.create(:artefact, slug: "related-artefact-2", name: "Cake", state: 'live')
         ]
 
-        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                        :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend', related_artefacts: index_related_artefacts)
 
 
@@ -196,7 +196,7 @@ class TravelAdviceTest < GovUkContentApiTest
           FactoryGirl.create(:artefact, slug: "related-artefact-3", name: "Burgers", state: 'draft')
         ]
 
-        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                        :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend', related_artefacts: index_related_artefacts)
 
 
@@ -228,7 +228,7 @@ class TravelAdviceTest < GovUkContentApiTest
           FactoryGirl.create(:artefact, slug: "related-artefact-2", name: "Cake", state: 'live')
         ]
 
-        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                        :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend', related_artefacts: index_related_artefacts)
         aruba_related_artefacts = [
           shared_artefact,
@@ -257,7 +257,7 @@ class TravelAdviceTest < GovUkContentApiTest
         FactoryGirl.create(:tag, :tag_id => 'coastal-resorts', :title => 'Coastal resorts', :tag_type => 'section')
         FactoryGirl.create(:tag, :tag_id => 'good-food', :title => 'Good food', :tag_type => 'section')
 
-        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                              :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend', sections: ['coastal-resorts'])
         country_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice/aruba', :state => 'live',
                                         :kind => 'travel-advice', :owning_app => 'travel-advice-publisher', sections: ['good-food'])
@@ -275,7 +275,7 @@ class TravelAdviceTest < GovUkContentApiTest
       it "should not duplicate tags which appear on both the index and the country artefact" do
         FactoryGirl.create(:tag, :tag_id => 'surfing', :title => 'Surfing', :tag_type => 'section')
 
-        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_id => '133',
+        travel_index_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice', :state => 'live', :need_ids => ['100003'],
                                              :owning_app => 'travel-advice-publisher', :rendering_app => 'frontend', sections: ['surfing'])
         country_artefact = FactoryGirl.create(:artefact, :slug => 'foreign-travel-advice/aruba', :state => 'live',
                                         :kind => 'travel-advice', :owning_app => 'travel-advice-publisher', sections: ['surfing'])


### PR DESCRIPTION
1. updating tests to setup correct data
2. testing that Artefact.any_in searches
   within the need_ids Array for the need_id
   being looked-up
3. adding need_ids to the ArtefactPresenter
4. using latest version of govuk_content_models
   that provides support for multiple need_ids
