### PR TITLE
Add airbrake support so we can send errors to errbit.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'rack-cache', '1.2'
 gem 'dalli', '2.6.4'
 
 gem 'rack-logstasher', '0.0.3'
+gem 'airbrake', '4.0.0'
 
 group :test do
   gem 'database_cleaner', '0.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,9 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.3.2)
+    airbrake (4.0.0)
+      builder
+      multi_json
     ansi (1.4.3)
     arel (3.0.2)
     aws-ses (0.5.0)
@@ -230,6 +233,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.0.0)
   aws-ses (= 0.5.0)
   ci_reporter (= 1.7.0)
   dalli (= 2.6.4)

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,6 @@
 require_relative 'env'
 require_relative 'lib/exception_mailer'
+require 'airbrake'
 
 configure do
   mongoid_config_file = File.expand_path("mongoid.yml", File.dirname(__FILE__))
@@ -13,3 +14,7 @@ end
 
 initializers_path = File.expand_path('config/initializers/*.rb', File.dirname(__FILE__))
 Dir[initializers_path].each { |f| require f }
+
+configure do
+  use Airbrake::Sinatra
+end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,1 @@
+# This is overwritten on deploy

--- a/lib/tasks/airbrake.rake
+++ b/lib/tasks/airbrake.rake
@@ -1,0 +1,3 @@
+require 'airbrake/tasks'
+
+require_relative '../../config/initializers/airbrake'


### PR DESCRIPTION
This leaves the existing email notification of exceptions in place.
That can be removed once we've verified that airbrake is working as
expected.
