### PR TITLE
Remove router-client gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ end
 
 gem 'govspeak', '1.5.1'
 gem 'plek', '1.7.0'
-gem 'router-client', '3.1.0', :require => false
 gem 'yajl-ruby'
 gem 'aws-ses', '0.5.0'
 gem 'kaminari', '0.14.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,10 +182,6 @@ GEM
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    router-client (3.1.0)
-      activesupport
-      builder
-      null_logger
     sanitize (2.0.6)
       nokogiri (>= 1.4.4)
     simplecov (0.6.4)
@@ -249,7 +245,6 @@ DEPENDENCIES
   rack-cache (= 1.2)
   rack-logstasher (= 0.0.3)
   rake (= 0.9.2.2)
-  router-client (= 3.1.0)
   simplecov (= 0.6.4)
   simplecov-rcov (= 0.2.3)
   sinatra (= 1.3.2)


### PR DESCRIPTION
This is unused - it was only ever used with the old scala router.  The
new router uses a client in gds-api-adapters
