### PR TITLE
Fix version number conflict in a test

### DIFF
--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -349,8 +349,8 @@ class ArtefactRequestTest < GovUkContentApiTest
 
     it "gets the published edition if a previous archived edition exists" do
       artefact = FactoryGirl.create(:artefact, state: 'live')
-      edition = FactoryGirl.create(:edition, state: 'archived', panopticon_id: artefact.id)
-      FactoryGirl.create(:edition, state: 'published', panopticon_id: artefact.id)
+      edition = FactoryGirl.create(:edition, state: 'archived', panopticon_id: artefact.id, version_number: 1)
+      FactoryGirl.create(:edition, state: 'published', panopticon_id: artefact.id, version_number: 2)
 
       get "/#{edition.artefact.slug}.json"
 


### PR DESCRIPTION
The edition factory, by default, tries to create editions with the same version number. When we're creating two artefacts, this will fail silently when we have [the database-level version uniqueness constraint](https://github.com/alphagov/govuk_content_models/pull/158).
