### PR TITLE
Generalise content storage and presentation for specialist docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '12.2.0'
+  gem 'govuk_content_models', '13.0.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       kramdown (~> 0.13.3)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.0.3)
-    govuk_content_models (12.2.0)
+    govuk_content_models (13.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -232,7 +232,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 9.2.0)
   govspeak (= 1.5.4)
-  govuk_content_models (= 12.2.0)
+  govuk_content_models (= 13.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -27,6 +27,7 @@ require "presenters/tagged_artefact_presenter"
 require "presenters/grouped_result_set_presenter"
 require "presenters/manual_artefact_presenter"
 require "presenters/manual_change_history_presenter"
+require "presenters/specialist_document_presenter"
 require "govspeak_formatter"
 
 # Note: the artefact patch needs to be included before the Kaminari patch,
@@ -529,6 +530,7 @@ class GovUkContentApi < Sinatra::Application
         presenters.unshift(ManualChangeHistoryPresenter)
       else
         attach_specialist_publisher_edition(@artefact)
+        presenters.unshift(SpecialistDocumentPresenter)
         formatter_options.merge!(auto_ids: true)
       end
     end

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -45,16 +45,6 @@ class ArtefactPresenter
     video_summary
     video_url
     will_continue_on
-    opened_date
-    closed_date
-    case_type
-    case_type_label
-    case_state
-    case_state_label
-    market_sector
-    market_sector_label
-    outcome_type
-    outcome_type_label
   ).map(&:to_sym)
 
   def initialize(artefact, url_helper, govspeak_formatter)
@@ -97,7 +87,6 @@ class ArtefactPresenter
       assets,
       country,
       organisation,
-      specialist_document_fields
     ].inject(&:merge)
 
     presented["related_external_links"] = @artefact.external_links.map do |l|
@@ -128,16 +117,6 @@ private
         [field, field_value]
       end
     end]
-  end
-
-  def specialist_document_fields
-    if @artefact.kind == 'specialist-document'
-      {
-        "headers" => @artefact.edition.headers,
-      }
-    else
-      {}
-    end
   end
 
   def parts

--- a/lib/presenters/specialist_document_presenter.rb
+++ b/lib/presenters/specialist_document_presenter.rb
@@ -1,0 +1,29 @@
+class SpecialistDocumentPresenter
+  def initialize(artefact_presenter)
+    @artefact_presenter = artefact_presenter
+  end
+
+  def edition
+    @artefact_presenter.edition
+  end
+
+  def present(*args, &block)
+    orig = @artefact_presenter.present(*args, &block)
+
+    orig.merge(
+      "details" => orig
+        .fetch("details")
+        .merge(document_specific_details),
+    )
+  end
+
+private
+
+  def document_specific_details
+    rendered_document.details
+  end
+
+  def rendered_document
+    edition
+  end
+end

--- a/test/requests/specialist_document_test.rb
+++ b/test/requests/specialist_document_test.rb
@@ -14,17 +14,11 @@ class SpecialistDocumentTest < GovUkContentApiTest
         title: "Private Healthcare Investigation",
         summary: "This is the summary",
         body: "<p>This is the body</p>",
-        opened_date: Date.parse("2013-03-21"),
-        closed_date: nil,
-        case_type: "market-investigation",
-        case_type_label: "Market investigation",
-        case_state: "open",
-        case_state_label: "Open",
-        market_sector: "healthcare",
-        market_sector_label: "Healthcare",
-        outcome_type: "referred",
-        outcome_type_label: "Referred",
-        headers: [],
+        details: {
+          "opened_date" => "2013-03-21",
+          "case_type" => "market-investigation",
+          "case_type_label" => "Market investigation",
+        }
       }
 
       document_attributes = document_defaults.merge(document_attributes)
@@ -55,11 +49,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
       assert_equal 'Private Healthcare Investigation', parsed_response["title"]
       assert_equal 'This is the summary', parsed_response["details"]["summary"]
       assert_equal '2013-03-21', parsed_response["details"]["opened_date"]
-      assert_equal nil, parsed_response["details"]["closed_date"]
       assert_equal "market-investigation", parsed_response["details"]["case_type"]
-      assert_equal "open", parsed_response["details"]["case_state"]
-      assert_equal "healthcare", parsed_response["details"]["market_sector"]
-      assert_equal "referred", parsed_response["details"]["outcome_type"]
     end
 
     it "should include facet labels in the json" do
@@ -67,9 +57,6 @@ class SpecialistDocumentTest < GovUkContentApiTest
       get '/mhra-drug-alerts/private-healthcare-investigation.json'
 
       assert_equal "Market investigation", parsed_response["details"]["case_type_label"]
-      assert_equal "Open", parsed_response["details"]["case_state_label"]
-      assert_equal "Healthcare", parsed_response["details"]["market_sector_label"]
-      assert_equal "Referred", parsed_response["details"]["outcome_type_label"]
     end
 
     it "should include the body of the rendered document" do
@@ -80,36 +67,6 @@ class SpecialistDocumentTest < GovUkContentApiTest
       get "/#{@artefact.slug}.json"
 
       assert_equal html_body, parsed_response['details']['body']
-    end
-
-    it "should provide hierarchical headers for the document body" do
-      example_headers = [
-        {
-          "text" => "Heading",
-          "id" => "heading",
-          "level" => 2,
-          "headers" => [
-            {
-              "text" => "Subheading",
-              "id" => "subheading",
-              "level" => 3,
-              "headers" => []
-            }
-          ]
-        }
-      ]
-
-      build_rendered_specialist_document!(headers: example_headers)
-
-      get "#{@artefact.slug}.json"
-
-      if last_response.ok?
-        actual_headers = JSON.parse(last_response.body).fetch("details").fetch("headers")
-
-        assert_equal example_headers, actual_headers
-      else
-        fail "RESPONSE: #{last_response.status}" + last_response.body
-      end
     end
   end
 


### PR DESCRIPTION
All document specific fields will be stored in a Hash field such that all
document types can be handled by a single mongoid class and presenter.

Adding more specialist document types should not require changes to the
Content API.

Depends on https://github.com/alphagov/govuk_content_models/pull/181

https://trello.com/c/bdpaMmOC/152-aaib-finder-publishing-aaib-reports-3
## Tasks before merging
- [x] Deploy the changes to Specialist Publisher in https://github.com/alphagov/specialist-publisher/pull/141
- [x] Republish all CMA cases so they include the new details hash
