### PR TITLE
Rename creds constant for clarity

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -779,7 +779,7 @@ class GovUkContentApi < Sinatra::Application
   end
 
   def asset_manager_api
-    options = Object::const_defined?(:API_CLIENT_CREDENTIALS) ? API_CLIENT_CREDENTIALS : {
+    options = Object::const_defined?(:ASSET_MANAGER_API_CREDENTIALS) ? ASSET_MANAGER_API_CREDENTIALS : {
       bearer_token: ENV['CONTENTAPI_ASSET_MANAGER_BEARER_TOKEN']
     }
     super(options)

--- a/test/requests/travel_advice_test.rb
+++ b/test/requests/travel_advice_test.rb
@@ -390,7 +390,7 @@ class TravelAdviceTest < GovUkContentApiTest
       end
 
       it "should authenticate with asset-manager if configured" do
-        ::API_CLIENT_CREDENTIALS = {:bearer_token => "foobar"}
+        ::ASSET_MANAGER_API_CREDENTIALS = {:bearer_token => "foobar"}
         GovUkContentApi.instance_variable_set('@asset_manager_api', nil)
 
         artefact = FactoryGirl.create(:artefact, slug: 'foreign-travel-advice/aruba', state: 'live',
@@ -432,8 +432,8 @@ class TravelAdviceTest < GovUkContentApiTest
       end
 
       after do
-        if Object.const_defined?(:API_CLIENT_CREDENTIALS)
-          Object.instance_eval { remove_const(:API_CLIENT_CREDENTIALS) }
+        if Object.const_defined?(:ASSET_MANAGER_API_CREDENTIALS)
+          Object.instance_eval { remove_const(:ASSET_MANAGER_API_CREDENTIALS) }
         end
       end
     end


### PR DESCRIPTION
Make it clear that the contained token is for asset-manager only, not for any api clients.

**Note:** https://github.gds/gds/alphagov-deployment/pull/661 needs to be merged first.
