### PR TITLE
Bump content models to 16.1.1 for tag draft parent fix.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '16.1.0'
+  gem 'govuk_content_models', '16.1.1'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       kramdown (~> 0.13.3)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.0.3)
-    govuk_content_models (16.1.0)
+    govuk_content_models (16.1.1)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 9.3.0)
   govspeak (= 1.5.4)
-  govuk_content_models (= 16.1.0)
+  govuk_content_models (= 16.1.1)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)


### PR DESCRIPTION
See https://github.com/alphagov/govuk_content_models/pull/202 for details.
