### PR TITLE
All Specialist Documents now have a published_at field.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '16.1.1'
+  gem 'govuk_content_models', '16.2.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       kramdown (~> 0.13.3)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.0.3)
-    govuk_content_models (16.1.1)
+    govuk_content_models (16.2.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 9.3.0)
   govspeak (= 1.5.4)
-  govuk_content_models (= 16.1.1)
+  govuk_content_models (= 16.2.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/lib/presenters/specialist_document_presenter.rb
+++ b/lib/presenters/specialist_document_presenter.rb
@@ -20,7 +20,11 @@ class SpecialistDocumentPresenter
 private
 
   def document_specific_details
-    rendered_document.details
+    rendered_document
+      .details
+      .merge({
+        "published_at" => rendered_document.read_attribute(:published_at)
+      })
   end
 
   def rendered_document


### PR DESCRIPTION
This will be required to fulfil [this trello ticket](https://trello.com/c/K1rcmRCw/242-bug-fix-updated-at-dates-on-all-specialist-publisher-documents-so-that-they-don-t-change-when-a-draft-is-saved-2)
- [x] Merge content-models pull request https://github.com/alphagov/govuk_content_models/pull/204
- [x] Update version of content models used in content_api
- [x] Deploy new specialist-publisher and republish all existing documents, to give them a published_at field
