### PR TITLE
Include owning_app in artefacts index output.

### DIFF
--- a/lib/presenters/minimal_artefact_presenter.rb
+++ b/lib/presenters/minimal_artefact_presenter.rb
@@ -4,7 +4,7 @@
 # in the artefact list where we don't want to look up any extra information
 # across collections.
 class MinimalArtefactPresenter
-  REQUIRED_FIELDS = [:name, :kind, :slug]
+  REQUIRED_FIELDS = [:name, :kind, :slug, :owning_app]
 
   def initialize(artefact, url_helper)
     @artefact = artefact
@@ -17,6 +17,7 @@ class MinimalArtefactPresenter
       "web_url" => @url_helper.artefact_web_url(@artefact),
       "title" => edition_or_artefact_title,
       "format" => edition_or_artefact_format,
+      "owning_app" => @artefact.owning_app,
     }
   end
 

--- a/test/requests/artefacts_request_test.rb
+++ b/test/requests/artefacts_request_test.rb
@@ -46,7 +46,7 @@ class ArtefactsRequestTest < GovUkContentApiTest
   end
 
   it "should only include minimal information for each artefact" do
-    FactoryGirl.create(:artefact, :slug => "bravo", :name => "Bravo", :state => 'live', :kind => "guide")
+    FactoryGirl.create(:artefact, :slug => "bravo", :name => "Bravo", :state => 'live', :kind => "guide", :owning_app => "calendars")
 
     get "/artefacts.json"
 
@@ -59,11 +59,12 @@ class ArtefactsRequestTest < GovUkContentApiTest
 
     result = parsed_response["results"].first
 
-    assert_equal %w(id web_url title format).sort, result.keys.sort
+    assert_equal %w(id web_url title format owning_app).sort, result.keys.sort
     assert_equal "Bravo", result["title"]
     assert_equal "guide", result["format"]
     assert_equal "#{public_web_url}/bravo", result["web_url"]
     assert_equal "http://example.org/bravo.json", result["id"]
+    assert_equal "calendars", result["owning_app"]
   end
 
   describe "pagination" do


### PR DESCRIPTION
Needed to seed reserved URLs in the url-arbiter.
