### PR TITLE
Remove fact-cave integration.

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -71,9 +71,9 @@ class GovUkContentApi < Sinatra::Application
 
   def govspeak_formatter(options = {})
     if params[:content_format] == "govspeak"
-      GovspeakFormatter.new(:govspeak, fact_cave_api, options)
+      GovspeakFormatter.new(:govspeak, options)
     else
-      GovspeakFormatter.new(:html, fact_cave_api, options)
+      GovspeakFormatter.new(:html, options)
     end
   end
 

--- a/lib/govspeak_formatter.rb
+++ b/lib/govspeak_formatter.rb
@@ -1,35 +1,19 @@
 class GovspeakFormatter
 
-  EMBEDDED_FACT_REGEXP = /\[fact\:([a-z0-9-]+)\]/i # e.g. [fact:vat-rates]
-
-  def initialize(format, fact_cave_api, options = {})
+  def initialize(format, options = {})
     unless [:html, :govspeak].include? format
       raise ArgumentError.new("Invalid format #{format}")
     end
 
     @format = format
-    @fact_cave_api = fact_cave_api
     @auto_ids = options.fetch(:auto_ids, false)
   end
 
   def format(govspeak_string)
     if @format == :html
-      formatted = Govspeak::Document.new(govspeak_string, auto_ids: @auto_ids).to_html
+      Govspeak::Document.new(govspeak_string, auto_ids: @auto_ids).to_html
     else
-      formatted = govspeak_string
-    end
-
-    interpolate_fact_values(formatted)
-  end
-
-private
-  def interpolate_fact_values(string)
-    string.gsub(EMBEDDED_FACT_REGEXP) do |match|
-      if fact = @fact_cave_api.fact($1)
-        fact.details.formatted_value
-      else
-        ''
-      end
+      govspeak_string
     end
   end
 end

--- a/test/unit/govspeak_formatter_test.rb
+++ b/test/unit/govspeak_formatter_test.rb
@@ -1,22 +1,14 @@
 require "test_helper"
 require "govspeak_formatter"
 require "gds_api/helpers"
-require "gds_api/test_helpers/fact_cave"
 
 describe GovspeakFormatter do
 
   describe "format" do
     include GdsApi::Helpers
-    include GdsApi::TestHelpers::FactCave
-
-    def empty_fact_cave
-      stub("empty fact cave") do
-        stubs(:fact).returns(nil)
-      end
-    end
 
     it "should convert govspeak to html" do
-      formatter = GovspeakFormatter.new(:html, empty_fact_cave)
+      formatter = GovspeakFormatter.new(:html)
       assert_equal(
         "<h1>GOVUK Govspeak</h1>\n\n<h2>Headings</h2>\n",
         formatter.format("# GOVUK Govspeak\n\n## Headings")
@@ -24,7 +16,7 @@ describe GovspeakFormatter do
     end
 
     it "should add automatic header ids when requested" do
-      formatter = GovspeakFormatter.new(:html, empty_fact_cave, auto_ids: true)
+      formatter = GovspeakFormatter.new(:html, auto_ids: true)
       assert_equal(
         %Q{<h2 id="govspeak">Govspeak</h2>\n},
         formatter.format("## Govspeak")
@@ -32,50 +24,10 @@ describe GovspeakFormatter do
     end
 
     it "should return unformatted govspeak when requested" do
-      formatter = GovspeakFormatter.new(:govspeak, empty_fact_cave)
+      formatter = GovspeakFormatter.new(:govspeak)
       assert_equal(
         "# GOVUK Govspeak\n\n## Headings",
         formatter.format("# GOVUK Govspeak\n\n## Headings")
-      )
-    end
-
-    it "should interpolate fact values into content when requested as govspeak" do
-      fact_cave_has_a_fact('vat-rate', '20%')
-      formatter = GovspeakFormatter.new(:govspeak, fact_cave_api)
-      assert_equal(
-        "## The current VAT rate is 20%",
-        formatter.format("## The current VAT rate is [fact:vat-rate]")
-      )
-    end
-
-    it "should interpolate fact values into content and format govspeak" do
-      fact_cave_has_a_fact('vat-rate', '20%')
-      fact_cave_has_a_fact('pi-2-decimal-places', '3.14')
-
-      formatter = GovspeakFormatter.new(:html, fact_cave_api)
-      assert_equal(
-        "<p><em>The current VAT rate is 20%, PI is approx. 3.14</em></p>\n",
-        formatter.format("*The current VAT rate is [Fact:vat-rate], PI is approx. [Fact:pi-2-decimal-places]*")
-      )
-    end
-
-    it "should replace fact content markers with an empty string where no value exists" do
-      fact_cave_does_not_have_a_fact('foo')
-      formatter = GovspeakFormatter.new(:html, fact_cave_api)
-      assert_equal(
-        "<p>The value of foo is </p>\n",
-        formatter.format("The value of foo is [Fact:foo]")
-      )
-    end
-
-    it "should interpolate formatted fact values into content" do
-      test_date = Date.new(2013, 9, 24)
-      fact_cave_has_a_fact('some-date', test_date, :type => :date)
-
-      formatter = GovspeakFormatter.new(:html, fact_cave_api)
-      assert_equal(
-        "<p>Some date is 24 September 2013 okay.</p>\n",
-        formatter.format("Some date is [Fact:some-date] okay.")
       )
     end
   end


### PR DESCRIPTION
fact-cave is being retired in its current form, so we don't want to
attempt to lookup facts in it any more.

There was only one edition that was using this, and that's now been updated - https://publisher.production.alphagov.co.uk/editions/54467d6940f0b67fc8000133/diff.
