### PR TITLE
Replace expectations with need_to_know

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '17.1.0'
+  gem 'govuk_content_models', '26.0.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2
@@ -15,14 +15,15 @@ end
 # as a dependency of govuk_content_models
 gem 'mongo', '>= 1.7.1'
 
-gem 'gds-sso', '9.3.0'
+gem 'gds-sso', '10.0.0'
+
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
   gem 'gds-api-adapters', '10.14.0'
 end
 
-gem 'govspeak', '~> 2.0'
+gem 'govspeak', '~> 3.1'
 gem 'plek', '1.7.0'
 gem 'yajl-ruby'
 gem 'kaminari', '0.14.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    gds-sso (9.3.0)
+    gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -67,17 +67,17 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govspeak (2.0.2)
+    govspeak (3.1.1)
       htmlentities (~> 4)
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (17.1.0)
+    govuk_content_models (26.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 7.0.0, < 10.0.0)
-      govspeak (~> 2.0.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
       mongoid (~> 2.5)
       plek
       state_machine
@@ -235,9 +235,9 @@ DEPENDENCIES
   database_cleaner (= 0.7.2)
   factory_girl (= 3.6.1)
   gds-api-adapters (= 10.14.0)
-  gds-sso (= 9.3.0)
-  govspeak (~> 2.0)
-  govuk_content_models (= 17.1.0)
+  gds-sso (= 10.0.0)
+  govspeak (~> 3.1)
+  govuk_content_models (= 26.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -36,6 +36,7 @@ class ArtefactPresenter
     min_value
     minutes_to_complete
     more_information
+    need_to_know
     organiser
     place_type
     reviewed_at
@@ -83,7 +84,6 @@ class ArtefactPresenter
       local_authority,
       local_interaction,
       local_service,
-      expectations,
       assets,
       country,
       organisation,
@@ -216,14 +216,6 @@ private
         "lgsl_code" => @artefact.edition.service.lgsl_code,
         "providing_tier" => @artefact.edition.service.providing_tier
       }
-    }
-  end
-
-  def expectations
-    return {} unless @artefact.edition.respond_to?(:expectations)
-
-    {
-      "expectations" => @artefact.edition.expectations.map(&:text)
     }
   end
 

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -217,10 +217,9 @@ class FormatsRequestTest < GovUkContentApiTest
 
   it "should work with local_transaction_edition" do
     service = FactoryGirl.create(:local_service, lgsl_code: 42)
-    expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-transaction', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     local_transaction_edition = FactoryGirl.create(:local_transaction_edition, slug: artefact.slug, lgsl_code: 42, lgil_override: 3345,
-                                expectation_ids: [expectation.id], minutes_to_complete: 3,
+                                need_to_know: "- Credit card required", minutes_to_complete: 3,
                                 introduction: "batman introduction", more_information: "batman more_information",
                                 panopticon_id: artefact.id, state: 'published')
     get '/batman-transaction.json'
@@ -231,7 +230,7 @@ class FormatsRequestTest < GovUkContentApiTest
 
     fields = parsed_response["details"]
     expected_fields = ['lgsl_code', 'lgil_override', 'introduction', 'more_information',
-                        'minutes_to_complete', 'expectations']
+                        'minutes_to_complete', 'need_to_know']
 
     assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>batman introduction</p>", fields["introduction"].strip
@@ -239,13 +238,13 @@ class FormatsRequestTest < GovUkContentApiTest
     assert_equal "3", fields["minutes_to_complete"]
     assert_equal 42, fields["lgsl_code"]
     assert_equal 3345, fields["lgil_override"]
+    assert_equal "<ul>\n  <li>Credit card required</li>\n</ul>\n", fields["need_to_know"]
   end
 
   it "should work with transaction_edition" do
-    expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-transaction', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
     transaction_edition = FactoryGirl.create(:transaction_edition, slug: artefact.slug,
-                                expectation_ids: [expectation.id], minutes_to_complete: 3,
+                                need_to_know: "- Credit card required", minutes_to_complete: 3,
                                 introduction: "batman introduction", more_information: "batman more_information",
                                 alternate_methods: "batman alternate_methods",
                                 will_continue_on: "A Site", link: "http://www.example.com/foo",
@@ -258,11 +257,12 @@ class FormatsRequestTest < GovUkContentApiTest
 
     fields = parsed_response["details"]
     expected_fields = ['alternate_methods', 'will_continue_on', 'link', 'introduction', 'more_information',
-                        'expectations']
+                        'need_to_know']
 
     assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>batman introduction</p>", fields["introduction"].strip
     assert_equal "<p>batman more_information</p>", fields["more_information"].strip
+    assert_equal "<ul>\n  <li>Credit card required</li>\n</ul>\n", fields["need_to_know"]
     assert_equal "<p>batman alternate_methods</p>", fields["alternate_methods"].strip
     assert_equal "3", fields["minutes_to_complete"]
     assert_equal "A Site", fields["will_continue_on"]
@@ -297,9 +297,8 @@ class FormatsRequestTest < GovUkContentApiTest
   end
 
   it "should work with place_edition" do
-    expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-place', owning_app: 'publisher', sections: [@tag1.tag_id], state: 'live')
-    place_edition = FactoryGirl.create(:place_edition, slug: artefact.slug, expectation_ids: [expectation.id],
+    place_edition = FactoryGirl.create(:place_edition, slug: artefact.slug, need_to_know: "- Available only in England",
                                 introduction: "batman introduction", more_information: "batman more_information",
                                 place_type: "batman-locations",
                                 minutes_to_complete: 3, panopticon_id: artefact.id, state: 'published')
@@ -310,12 +309,13 @@ class FormatsRequestTest < GovUkContentApiTest
     assert_base_artefact_fields(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['introduction', 'more_information', 'place_type', 'expectations']
+    expected_fields = ['introduction', 'more_information', 'place_type', 'need_to_know']
 
     assert_has_expected_fields(fields, expected_fields)
     assert_equal "<p>batman introduction</p>", fields["introduction"].strip
     assert_equal "<p>batman more_information</p>", fields["more_information"].strip
     assert_equal "batman-locations", fields["place_type"]
+    assert_equal "<ul>\n  <li>Available only in England</li>\n</ul>\n", fields["need_to_know"]
   end
 
   describe "help pages" do

--- a/test/requests/place_format_test.rb
+++ b/test/requests/place_format_test.rb
@@ -6,11 +6,10 @@ class PlaceFormatTest < GovUkContentApiTest
 
   def setup
     super
-    expectation = FactoryGirl.create(:expectation)
     artefact = FactoryGirl.create(:artefact, slug: 'batman-place', owning_app: 'publisher', state: 'live')
     place_edition = FactoryGirl.create(:place_edition, 
                                 place_type: "batman-place",
-                                slug: artefact.slug, expectation_ids: [expectation.id],
+                                slug: artefact.slug, need_to_know: "- Available only in England",
                                 minutes_to_complete: 3, panopticon_id: artefact.id, state: 'published')
   end
 
@@ -53,7 +52,7 @@ class PlaceFormatTest < GovUkContentApiTest
     assert_base_artefact_fields(parsed_response)
 
     fields = parsed_response["details"]
-    expected_fields = ['introduction', 'more_information', 'place_type', 'expectations']
+    expected_fields = ['introduction', 'more_information', 'place_type', 'need_to_know']
 
     assert_has_expected_fields(fields, expected_fields)
   end

--- a/test/requests/specialist_document_test.rb
+++ b/test/requests/specialist_document_test.rb
@@ -8,7 +8,6 @@ class SpecialistDocumentTest < GovUkContentApiTest
 
   describe "loading a published specialist document" do
     def build_rendered_specialist_document!(document_attributes = {})
-
       document_defaults = {
         slug: "mhra-drug-alerts/private-healthcare-investigation",
         title: "Private Healthcare Investigation",
@@ -26,7 +25,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
       @artefact = FactoryGirl.create(:artefact,
         slug: "mhra-drug-alerts/private-healthcare-investigation",
         state: "live",
-        kind: "specialist-document",
+        kind: "medical_safety_alert",
         owning_app: "specialist-publisher",
         name: "Private Healthcare Investigation"
       )
@@ -45,7 +44,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
       get '/mhra-drug-alerts/private-healthcare-investigation.json'
 
       assert_base_artefact_fields(parsed_response)
-      assert_equal 'specialist-document', parsed_response["format"]
+      assert_equal 'medical_safety_alert', parsed_response["format"]
       assert_equal 'Private Healthcare Investigation', parsed_response["title"]
       assert_equal 'This is the summary', parsed_response["details"]["summary"]
       assert_equal '2013-03-21', parsed_response["details"]["opened_date"]
@@ -181,7 +180,7 @@ class SpecialistDocumentTest < GovUkContentApiTest
       @artefact = FactoryGirl.create(:artefact,
         slug: "mhra-drug-alerts/private-healthcare-investigation",
         state: "live",
-        kind: "specialist-document",
+        kind: "medical_safety_alert",
         owning_app: "specialist-publisher",
         name: "Private Healthcare Investigation"
       )


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8707

Expectations are replaced with a freeform govspeak field `need_to_know`.
Related: https://github.com/alphagov/govuk_content_models/pull/257, https://github.com/alphagov/govuk_content_models/pull/258, https://github.com/alphagov/publisher/pull/321

includes test fixes to accommodate a [breaking change in govuk_content_models](https://github.com/alphagov/govuk_content_models/blob/master/CHANGELOG.md#1800) where `specialist-document` artefact kind was removed.
