### PR TITLE
Include downtime message in artefact presentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '26.0.0'
+  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'add-downtime-schedule'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'add-downtime-schedule'
+  gem "govuk_content_models", '~> 28.1.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/alphagov/govuk_content_models.git
+  revision: bf8e2f1693ae7bb8085ba36488316fd0d16177ac
+  branch: add-downtime-schedule
+  specs:
+    govuk_content_models (28.0.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -45,7 +59,6 @@ GEM
       safe_yaml (~> 1.0.0)
     dalli (2.6.4)
     database_cleaner (0.7.2)
-    differ (0.1.2)
     erubis (2.7.0)
     factory_girl (3.6.1)
       activesupport (>= 3.0.0)
@@ -72,15 +85,6 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (26.0.0)
-      bson_ext
-      differ
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
     hashie (3.2.0)
     hike (1.2.3)
     htmlentities (4.3.2)
@@ -237,7 +241,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1)
-  govuk_content_models (= 26.0.0)
+  govuk_content_models!
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/govuk_content_models.git
-  revision: bf8e2f1693ae7bb8085ba36488316fd0d16177ac
-  branch: add-downtime-schedule
-  specs:
-    govuk_content_models (28.0.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,6 +72,14 @@ GEM
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
     hashie (3.2.0)
+    govuk_content_models (28.1.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     hike (1.2.3)
     htmlentities (4.3.2)
     i18n (0.6.11)
@@ -241,7 +235,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1)
-  govuk_content_models!
+  govuk_content_models (~> 28.1.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -111,7 +111,7 @@ private
     Hash[fields.map do |field|
       field_value = @artefact.edition.send(field)
 
-      if @artefact.edition.class::GOVSPEAK_FIELDS.include?(field)
+      if @artefact.edition.class.const_defined?(:GOVSPEAK_FIELDS) && @artefact.edition.class::GOVSPEAK_FIELDS.include?(field)
         [field, @govspeak_formatter.format(field_value)]
       else
         [field, field_value]

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -86,6 +86,7 @@ class ArtefactPresenter
       assets,
       country,
       organisation,
+      downtime,
     ].inject(&:merge)
 
     presented["related_external_links"] = @artefact.external_links.map do |l|
@@ -227,6 +228,17 @@ private
         "url" => @artefact.edition.organisation_url,
         "brand_colour" => @artefact.edition.organisation_brand_colour,
         "crest" => @artefact.edition.organisation_crest,
+      }
+    }
+  end
+
+  def downtime
+    downtime = Downtime.for(@artefact)
+    return {} if downtime.nil? || !downtime.publicise?
+
+    {
+      "downtime" => {
+        "message" => downtime.message,
       }
     }
   end

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -142,6 +142,24 @@ class ArtefactRequestTest < GovUkContentApiTest
     end
   end
 
+  it 'should return a downtime message if downtime is scheduled' do
+    downtime = FactoryGirl.create(:downtime, artefact: FactoryGirl.create(:live_artefact_with_edition))
+
+    get "/#{downtime.artefact.slug}.json"
+
+    assert_equal 200, last_response.status
+    assert_equal downtime.message, JSON.parse(last_response.body)['details']['downtime']['message']
+  end
+
+  it 'should not return downtime details if downtime is not supposed to be publicised' do
+    faraway_downtime = FactoryGirl.create(:downtime, start_time: Date.today + 3, end_time: Date.today + 4, artefact: FactoryGirl.create(:live_artefact_with_edition))
+
+    get "/#{faraway_downtime.artefact.slug}.json"
+
+    assert_equal 200, last_response.status
+    assert_nil JSON.parse(last_response.body)['details']['downtime']
+  end
+
   it "should not look for edition if publisher not owner" do
     artefact = FactoryGirl.create(:non_publisher_artefact, state: 'live')
 

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -40,6 +40,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
                                 :locations => ['wales'],
                                 :sectors => ['manufacturing'],
                                 :support_types => ['award','loan'],
+                                :review_requested_at => Time.zone.now,
                                 :state => 'in_review')
       @ed5 = FactoryGirl.create(:business_support_edition,
                                 :panopticon_id => @artefact._id,


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8805

As a content designer
I want a better way to indicate on start pages when a service is down for planned maintenance
So that I don't have to re-edition multiple pages and push these through workflow, then repeat the process again once the downtime is over

related:
https://github.com/alphagov/govuk_content_models/pull/277
https://github.com/alphagov/publisher/pull/340
https://github.com/alphagov/frontend/pull/728