### PR TITLE
Remove reference to Rabl

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec mr-sparkle --force-polling --pattern "rabl|rb|ru|txt|yml" -- -p 3022
+bundle exec mr-sparkle --force-polling --pattern "rb|ru|txt|yml" -- -p 3022


### PR DESCRIPTION
Rabl is a templating system we used for generating JSON. We stopped using it a
while ago in c46a5d4759ef089538c89d2ec48fe5df237d1410