### PR TITLE
Completed Transaction has optional content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'edition-has-display-toggles'
+  gem "govuk_content_models", '28.6.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sinatra', '1.3.2'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 28.1.0'
+  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'edition-has-display-toggles'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-PATH
-  remote: ../govuk_content_models
-  specs:
-    govuk_content_models (28.5.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,6 +71,14 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
+    govuk_content_models (28.6.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     hashie (3.2.0)
     hike (1.2.3)
     htmlentities (4.3.2)
@@ -239,7 +235,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1)
-  govuk_content_models!
+  govuk_content_models (= 28.6.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+PATH
+  remote: ../govuk_content_models
+  specs:
+    govuk_content_models (28.5.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,14 +83,6 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (28.1.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
     hashie (3.2.0)
     hike (1.2.3)
     htmlentities (4.3.2)
@@ -235,7 +239,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.14.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1)
-  govuk_content_models (~> 28.1.0)
+  govuk_content_models!
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -38,6 +38,7 @@ class ArtefactPresenter
     need_to_know
     organiser
     place_type
+    presentation_toggles
     reviewed_at
     short_description
     summary

--- a/test/requests/completed_transaction_artefact_request_test.rb
+++ b/test/requests/completed_transaction_artefact_request_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class CompletedTransactionArtefactRequestTest < GovUkContentApiTest
+  it "should contain presentation toggles to indicate what promotions should be displayed" do
+    artefact = FactoryGirl.create(:artefact, state: 'live')
+    edition = FactoryGirl.create(:completed_transaction_edition, panopticon_id: artefact.id, state: 'published')
+    organ_donor_registration_url = "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign="
+
+    get "/#{artefact.slug}.json"
+    assert_equal 200, last_response.status
+    response = JSON.parse(last_response.body)
+    refute response["details"]["presentation_toggles"]["organ_donor_registration"]["promote_organ_donor_registration"]
+
+    edition.promote_organ_donor_registration = true
+    edition.organ_donor_registration_url = organ_donor_registration_url
+    edition.save(validate: false)
+
+    get "/#{artefact.slug}.json"
+    assert_equal 200, last_response.status
+    response = JSON.parse(last_response.body)
+    assert response["details"]["presentation_toggles"]["organ_donor_registration"]["promote_organ_donor_registration"]
+    assert_equal organ_donor_registration_url, response["details"]["presentation_toggles"]["organ_donor_registration"]["organ_donor_registration_url"]
+  end
+end


### PR DESCRIPTION
https://trello.com/c/caDndyIX

Completed transactions have `presentation_toggles`, which control what elements should be optionally displayed on the transaction completed page: https://github.com/alphagov/govuk_content_models/pull/292

We need to conditionally display an organ donor registration block with a URL.