### PR TITLE
Fix content-api for rack-protection v1.5.1+

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -21,7 +21,6 @@ in_development = ENV['RACK_ENV'] == 'development'
 if in_development
   set :logging, Logger::DEBUG
   # Lets the JS work with different hostnames in development
-  set :protection, :except => :json_csrf
 else
   enable :logging
 

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -53,6 +53,7 @@ class GovUkContentApi < Sinatra::Application
 
   set :views, File.expand_path('views', File.dirname(__FILE__))
   set :show_exceptions, false
+  set :protection, :except => :path_traversal
 
   def url_helper
     parameters = [self, Plek.current.website_root, env['HTTP_API_PREFIX']]

--- a/test/requests/tag_request_test.rb
+++ b/test/requests/tag_request_test.rb
@@ -152,4 +152,48 @@ class TagRequestTest < GovUkContentApiTest
       end
     end
   end
+
+  # The deprecated endpoint
+  describe "/tags/:tag_type_or_id.json" do
+    describe "for a tag id without a slash" do
+      before do
+        FactoryGirl.create(:live_tag, tag_id: "crime", tag_type: "section")
+      end
+
+      it "redirects to the non-deprecated endpoint with the default type" do
+        get "/tags/crime.json"
+
+        assert last_response.redirect?
+        assert_equal "http://example.org/tags/section/crime.json", last_response.location
+      end
+    end
+
+    describe "for a tag id with a slash" do
+      before do
+        crime = FactoryGirl.create(:live_tag,
+                                   tag_id: "crime",
+                                   tag_type: "section")
+
+        FactoryGirl.create(:live_tag,
+                           tag_id: "crime/batman",
+                           tag_type: "section",
+                           parent_id: crime.tag_id)
+
+      end
+
+      it "redirects a lower-cased path to the non-deprecated endpoint with the default type" do
+        get "/tags/crime%2fbatman.json"
+
+        assert last_response.redirect?, "was not a redirect"
+        assert_equal "http://example.org/tags/section/crime%2Fbatman.json", last_response.location
+      end
+
+      it "redirects an upper-cased path to the non-deprecated endpoint with the default type" do
+        get "/tags/crime%2Fbatman.json"
+
+        assert last_response.redirect?, "was not a redirect"
+        assert_equal "http://example.org/tags/section/crime%2Fbatman.json", last_response.location
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rack::Protection’s [path traversal protection](https://github.com/sinatra/rack-protection/blob/90f6a495736bcd2a49ef6ddcf38bc6290d64ba5a/lib/rack/protection/path_traversal.rb) converts encoded slashes
to normal slashes before passing to the app. This is not desired as
clients of the Content API may be requesting tags with slashes in the
name, so a path with `%2F` in is actually valid.

This has only recently broken because `rack-protection` v1.5.1 [changed
the regex](https://github.com/sinatra/rack-protection/commit/7875ec5378a0e43ac66592ba83083c861c43b02b#diff-165187da206c9e533cfba1546bd4b4bfR23) to be case-insensitive, it was previously only looking for
`%2f` whereas our clients were passing `%2F`.

The endpoint in question is actually deprecated, the new endpoint uses
a splat url parameter to work around this. We can’t easily do that here
as the deprecated endpoint would override the correct one.