### PR TITLE
Pass through the new department_analytics_profile field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '3.2.22'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '28.6.0'
+  gem "govuk_content_models", '28.9.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,11 +75,11 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (28.6.0)
+    govuk_content_models (28.9.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
+      govspeak (~> 3.1)
       mongoid (~> 2.5)
       plek
       state_machine
@@ -246,7 +246,7 @@ DEPENDENCIES
   gds-api-adapters (= 20.1.1)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1)
-  govuk_content_models (= 28.6.0)
+  govuk_content_models (= 28.9.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (= 3.4.0)

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -22,6 +22,7 @@ class ArtefactPresenter
     body
     change_description
     continuation_link
+    department_analytics_profile
     eligibility
     evaluation
     introduction

--- a/test/requests/specialist_document_test.rb
+++ b/test/requests/specialist_document_test.rb
@@ -126,55 +126,6 @@ class SpecialistDocumentTest < GovUkContentApiTest
     end
   end
 
-  describe 'loading a published manual section' do
-    def build_rendered_specialist_document!(document_attributes = {})
-
-      document_defaults = {
-        slug: 'guidance/immigration-rules/family-members',
-        title: 'Immigration rules part 8: family members',
-        summary: 'This is the summary',
-        body: '<p>This is the body</p>',
-      }
-
-      document_attributes = document_defaults.merge(document_attributes)
-
-      @artefact = FactoryGirl.create(:artefact,
-        slug: 'guidance/immigration-rules/family-members',
-        state: 'live',
-        kind: 'manual-section',
-        owning_app: 'specialist-publisher',
-        name: 'Immigration rules part 8: family members'
-      )
-
-      @document = FactoryGirl.create(:rendered_specialist_document, document_attributes)
-    end
-
-    it 'should return a successful response' do
-      build_rendered_specialist_document!
-      get "/#{@artefact.slug}.json"
-
-      assert last_response.ok?
-    end
-
-    it 'should return json containing the rendered document' do
-      build_rendered_specialist_document!
-      get "/#{@artefact.slug}.json"
-
-      assert_base_artefact_fields(parsed_response)
-      assert_equal 'manual-section', parsed_response["format"]
-      assert_equal 'Immigration rules part 8: family members', parsed_response["title"]
-    end
-
-    it 'should include the body of the rendered document' do
-      html_body = %Q{<h2 id="heading">Heading</h2>\n}
-
-      build_rendered_specialist_document!(body: html_body)
-      get "/#{@artefact.slug}.json"
-
-      assert_equal html_body, parsed_response['details']['body']
-    end
-  end
-
   describe "artefact but no rendered specialist document" do
     before do
       @artefact = FactoryGirl.create(:artefact,
@@ -190,52 +141,5 @@ class SpecialistDocumentTest < GovUkContentApiTest
       get '/mhra-drug-alerts/private-healthcare-investigation.json'
       assert last_response.not_found?
     end
-  end
-
-  describe 'loading manual change history' do
-    def build_change_history!
-      @manual_slug = 'guidance/immigration-rules'
-      @slug = "#{@manual_slug}/updates"
-
-      @updates = [
-        {
-          "published_at" => "2014-01-01T08:45:00",
-          "slug" => "#{@slug}/a-section",
-          "title" => "Manual section",
-          "change_note" => "Changed a thing",
-        },
-      ]
-
-      FactoryGirl.create(:artefact,
-        slug: @slug,
-        state: 'live',
-        kind: 'manual-change-history',
-        owning_app: 'specialist-publisher',
-        rendering_app: 'manuals-frontend',
-        name: 'Immigration rules updates',
-      )
-
-      ManualChangeHistory.create!(
-        slug: @slug,
-        manual_slug: @manual_slug,
-        updates: @updates,
-      )
-    end
-
-    it 'should return a successful response' do
-      build_change_history!
-      get "/#{@slug}.json"
-
-      assert last_response.ok?
-    end
-
-    it 'should return json containing the manual slug and updates' do
-      build_change_history!
-      get "/#{@slug}.json"
-
-      assert_equal 'manual-change-history', parsed_response["format"]
-      assert_equal 'Immigration rules updates', parsed_response["title"]
-    end
-
   end
 end


### PR DESCRIPTION
Frontend uses this field to populate the cross-domain tracking profile

Trello: https://trello.com/c/QyHwb1Zu/39-allow-editors-to-add-cross-domain-tracking-to-service-start-pages-medium