### PR TITLE
Add endpoint for bulk-fetching of whitehall-artefacts-with-browse-page-taggings

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -465,6 +465,21 @@ class GovUkContentApi < Sinatra::Application
     presenter.present.to_json
   end
 
+  # This endpoint is used by Whitehall to efficiently find out which mainstream
+  # browse pages an artefact is tagged to. Whitehall needs to send this
+  # information to rummager when indexing. This endpoint will be removed by the
+  # Finding Things team once a new tagging infrastructure is in place.
+  get '/whitehall-artefacts-tagged-to-mainstream-browse-pages.json' do
+    artefacts = Artefact.live.where(owning_app: 'whitehall', tags: { '$elemMatch' => { tag_type: 'section' } })
+
+    artefacts.map do |artefact|
+      {
+        artefact_slug: artefact.slug,
+        mainstream_browse_page_slugs: artefact.tags.select { |tag| tag.tag_type == 'section' }.map(&:tag_id)
+      }
+    end.to_json
+  end
+
   get "/*.json" do |id|
     # The edition param is for accessing unpublished editions in order for
     # editors to preview them. These can change frequently and so shouldn't be

--- a/test/requests/artefacts_tagged_to_browse_pages_test.rb
+++ b/test/requests/artefacts_tagged_to_browse_pages_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+
+class ArtefactsTaggedToBrowsePagesTest < GovUkContentApiTest
+  describe 'GET /whitehall-artefacts-tagged-to-mainstream-browse-pages.json' do
+    it 'returns whitehall artefacts tagged to mainstream browse pages' do
+      FactoryGirl.create(:live_tag, tag_id: 'food', tag_type: 'section')
+      FactoryGirl.create(:live_tag, tag_id: 'yo-food', tag_type: 'specialist_sector')
+      FactoryGirl.create(:live_tag, tag_id: 'food/pastries', parent_id: 'food', tag_type: 'section')
+      FactoryGirl.create(:whitehall_live_artefact, slug: 'government/food-is-good', section_ids: %w[food/pastries], specialist_sector_ids: %w[yo-food])
+
+      get '/whitehall-artefacts-tagged-to-mainstream-browse-pages.json'
+
+      assert_equal [{ 'artefact_slug' => 'government/food-is-good', 'mainstream_browse_page_slugs' => ['food/pastries'] }],
+        parsed_response
+    end
+
+    it 'does not return artefacts tagged to mainstream browse pages from other apps' do
+      FactoryGirl.create(:live_tag, tag_id: 'food', tag_type: 'section')
+      FactoryGirl.create(:artefact, :live, owning_app: 'trade-tariff', section_ids: %w[food])
+
+      get '/whitehall-artefacts-tagged-to-mainstream-browse-pages.json'
+
+      assert_equal [], parsed_response
+    end
+  end
+
+  def parsed_response
+    @parsed_response ||= JSON.parse(last_response.body)
+  end
+end


### PR DESCRIPTION
This endpoint is used by Whitehall to efficiently find out which mainstream browse pages an artefact is tagged to. Whitehall needs to send this information to rummager when indexing. This endpoint will be
removed once a new tagging infrastructure is in place.

Once this PR is merged we'll update https://github.com/alphagov/whitehall/pull/2322 to make it use this endpoint, so that Whitehall makes just one request to content-api, instead of 130.000.

Trello: https://trello.com/c/7qw4TRiC