### PR TITLE
Rescue and log more Licensify errors

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -683,6 +683,9 @@ class GovUkContentApi < Sinatra::Application
     artefact.licence = { "error" => "timed_out" }
   rescue GdsApi::HTTPErrorResponse
     artefact.licence = { "error" => "http_error" }
+  rescue => e
+    Airbrake.notify_or_ignore(e)
+    artefact.licence = { "error" => "http_error" }
   end
 
   def attach_travel_advice_country_and_edition(artefact, version_number = nil)


### PR DESCRIPTION
In all environments other than current production and current staging,
Licensify requests will abort with various error like `SocketError` due
to not being able to resolve the licensify hostname, or
`Errno::ENETUNREACH` due to the application being in a different vDC that
we can’t currently route to.

In these cases, we should log the error to Errbit, but return a
friendly error to frontend allowing it to still render the rest of the
licence page.

A future improvement to this would be to attempt to distinguish between
different types of error and indicate to the user whether the licence
isn’t available to apply for online just temporarily, or if it’s not
been added to licensify at all yet.

/cc @jennyd 