### PR TITLE
Include content_ids in API responses.

### DIFF
--- a/lib/presenters/minimal_artefact_presenter.rb
+++ b/lib/presenters/minimal_artefact_presenter.rb
@@ -4,7 +4,7 @@
 # in the artefact list where we don't want to look up any extra information
 # across collections.
 class MinimalArtefactPresenter
-  REQUIRED_FIELDS = [:name, :kind, :slug, :owning_app]
+  REQUIRED_FIELDS = [:content_id, :name, :kind, :slug, :owning_app]
 
   def initialize(artefact, url_helper)
     @artefact = artefact
@@ -14,6 +14,7 @@ class MinimalArtefactPresenter
   def present
     {
       "id" => @url_helper.artefact_url(@artefact),
+      "content_id" => @artefact.content_id,
       "web_url" => @url_helper.artefact_web_url(@artefact),
       "title" => edition_or_artefact_title,
       "format" => edition_or_artefact_format,

--- a/lib/presenters/tag_presenter.rb
+++ b/lib/presenters/tag_presenter.rb
@@ -8,6 +8,7 @@ class TagPresenter
   def present
     presented = {
       "id" => @url_helper.tag_url(@tag),
+      "content_id" => @tag.content_id,
       "slug" => @tag.tag_id,
       "web_url" => @url_helper.tag_web_url(@tag),
       "title" => @tag.title,

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -254,6 +254,15 @@ class ArtefactRequestTest < GovUkContentApiTest
     assert_equal 'smart-answer', response["format"]
   end
 
+  it "should set the content_id field at the top-level from the artefact" do
+    artefact = FactoryGirl.create(:non_publisher_artefact, state: 'live', :content_id => SecureRandom.uuid)
+    get "/#{artefact.slug}.json"
+
+    assert_equal 200, last_response.status
+    response = JSON.parse(last_response.body)
+    assert_equal artefact.content_id, response["content_id"]
+  end
+
   it "should set the language field in the details node of the artefact" do
     artefact = FactoryGirl.create(:non_publisher_artefact, state: 'live')
     get "/#{artefact.slug}.json"

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -181,13 +181,14 @@ class ArtefactRequestTest < GovUkContentApiTest
   end
 
   it "should list section information" do
+    crime = FactoryGirl.create(:live_tag, tag_id: "crime", content_id: SecureRandom.uuid, title: "Crime", tag_type: "section")
+    batman = FactoryGirl.create(:live_tag, tag_id: "crime/batman", content_id: SecureRandom.uuid, title: "Batman", tag_type: "section", parent_id: crime.tag_id)
+
     sections = [
-      { tag_id: 'crime', parent_id: nil, title: 'Crime' },
-      { tag_id: 'crime/batman', parent_id: 'crime', title: 'Batman' },
+      { tag_id: 'crime', parent_id: nil, title: 'Crime', content_id: crime.content_id },
+      { tag_id: 'crime/batman', parent_id: 'crime', title: 'Batman', content_id: batman.content_id },
     ]
 
-    parent = FactoryGirl.create(:live_tag, tag_id: "crime", title: "Crime", tag_type: "section")
-    FactoryGirl.create(:live_tag, tag_id: "crime/batman", title: "Batman", tag_type: "section", parent_id: parent.tag_id)
 
     artefact = FactoryGirl.create(:non_publisher_artefact,
         sections: sections.map { |section| section[:tag_id] },
@@ -205,6 +206,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal section[:title], tag_info["title"]
       tag_path = "/tags/section/#{CGI.escape(section[:tag_id])}.json"
       assert_equal tag_path, URI.parse(tag_info["id"]).path
+      assert_equal section[:content_id], tag_info["content_id"]
       assert_equal "section", tag_info["details"]["type"]
       # Temporary hack until the browse pages are rebuilt
       expected_section_slug = section[:tag_id]

--- a/test/requests/artefacts_request_test.rb
+++ b/test/requests/artefacts_request_test.rb
@@ -46,7 +46,7 @@ class ArtefactsRequestTest < GovUkContentApiTest
   end
 
   it "should only include minimal information for each artefact" do
-    FactoryGirl.create(:artefact, :slug => "bravo", :name => "Bravo", :state => 'live', :kind => "guide", :owning_app => "calendars")
+    artefact = FactoryGirl.create(:artefact, :slug => "bravo", :content_id => SecureRandom.uuid, :name => "Bravo", :state => 'live', :kind => "guide", :owning_app => "calendars")
 
     get "/artefacts.json"
 
@@ -59,11 +59,12 @@ class ArtefactsRequestTest < GovUkContentApiTest
 
     result = parsed_response["results"].first
 
-    assert_equal %w(id web_url title format owning_app).sort, result.keys.sort
+    assert_equal %w(id content_id web_url title format owning_app).sort, result.keys.sort
     assert_equal "Bravo", result["title"]
     assert_equal "guide", result["format"]
     assert_equal "#{public_web_url}/bravo", result["web_url"]
     assert_equal "http://example.org/bravo.json", result["id"]
+    assert_equal artefact.content_id, result["content_id"]
     assert_equal "calendars", result["owning_app"]
   end
 

--- a/test/requests/tag_request_test.rb
+++ b/test/requests/tag_request_test.rb
@@ -4,9 +4,10 @@ class TagRequestTest < GovUkContentApiTest
 
   describe "/tags/:tag_type/:tag_id.json" do
     it "should load a specific tag" do
-      FactoryGirl.create(:live_tag,
+      tag = FactoryGirl.create(:live_tag,
         tag_id: "good-tag",
         tag_type: "section",
+        content_id: SecureRandom.uuid,
         description: "Lots to say for myself"
       )
 
@@ -16,6 +17,7 @@ class TagRequestTest < GovUkContentApiTest
       response = JSON.parse(last_response.body)
       assert_equal "Lots to say for myself", response["details"]["description"]
       assert_equal "http://example.org/tags/section/good-tag.json", response["id"]
+      assert_equal tag.content_id, response["content_id"]
       assert_equal(
         "#{public_web_url}/browse/good-tag",
         response["web_url"]
@@ -123,15 +125,16 @@ class TagRequestTest < GovUkContentApiTest
 
     describe "has a parent tag" do
       before do
-        @parent = FactoryGirl.create(:live_tag, tag_id: 'crime-and-prison')
+        @parent = FactoryGirl.create(:live_tag, tag_id: 'crime-and-prison', content_id: SecureRandom.uuid)
       end
 
       it "should include the parent tag" do
-        tag = FactoryGirl.create(:live_tag, tag_id: 'crime', parent_id: @parent.tag_id)
+        tag = FactoryGirl.create(:live_tag, tag_id: 'crime', content_id: SecureRandom.uuid, parent_id: @parent.tag_id)
         get "/tags/section/crime.json"
         response = JSON.parse(last_response.body)
         expected = {
           "id" => "http://example.org/tags/section/crime-and-prison.json",
+          "content_id" => @parent.content_id,
           "slug" => "crime-and-prison",
           "web_url" => "#{public_web_url}/browse/crime-and-prison",
           "details"=>{

--- a/test/unit/presenters/tag_presenter_test.rb
+++ b/test/unit/presenters/tag_presenter_test.rb
@@ -7,6 +7,7 @@ describe TagPresenter do
     mock("tag") do
       expects(:title).returns("Tag")
       expects(:tag_id).returns('tag')
+      expects(:content_id).returns('a_uuid')
       expects(:tag_type).returns("section")
       expects(:short_description).returns("A tag for stuff")
       expects(:description).returns("A tag for stuff and things")
@@ -21,6 +22,7 @@ describe TagPresenter do
     presented = TagPresenter.new(mock_tag_without_parent, mock_url_helper).present
 
     assert_equal "Tag", presented["title"]
+    assert_equal "a_uuid", presented["content_id"]
     assert_equal "A tag for stuff", presented["details"]["short_description"]
     assert_equal "A tag for stuff and things", presented["details"]["description"]
     assert_equal "section", presented["details"]["type"]
@@ -69,7 +71,7 @@ describe TagPresenter do
   it "should instantiate a presenter for the tag's parent" do
     mock_parent = mock("parent")
     mock_tag = mock("tag") do
-      stubs(title: nil, tag_id: nil, tag_type: nil, short_description: nil, description: nil, state: nil)
+      stubs(title: nil, tag_id: nil, content_id: nil, tag_type: nil, short_description: nil, description: nil, state: nil)
       expects(:parent).with().times(1..2).returns(mock_parent)
     end
 


### PR DESCRIPTION
This adds content_ids to API responses for both artefacts and tags.

In the immediate term, this will help with testing stories related to adding content_ids to panopticon. In the longer term, this will help us keep the old-world and new-world in sync.