### PR TITLE
Allow querying business support schemes by gss

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -367,7 +367,7 @@ class GovUkContentApi < Sinatra::Application
     set_expiry
 
     facets = {}
-      [:areas, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
+    [:areas, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
       facets[key] = params[key] if params[key].present?
     end
 

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -367,7 +367,7 @@ class GovUkContentApi < Sinatra::Application
     set_expiry
 
     facets = {}
-    [:areas, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
+    [:areas, :area_gss_codes, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
       facets[key] = params[key] if params[key].present?
     end
 

--- a/lib/presenters/business_support_scheme_presenter.rb
+++ b/lib/presenters/business_support_scheme_presenter.rb
@@ -12,6 +12,7 @@ class BusinessSupportSchemePresenter
     base_presenter.present.merge({
       "short_description" => @artefact.edition.short_description,
       "areas" => @artefact.edition.areas,
+      "area_gss_codes" => @artefact.edition.area_gss_codes,
       "business_sizes" => @artefact.edition.business_sizes,
       "locations" => @artefact.edition.locations,
       "purposes" => @artefact.edition.purposes,

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -8,54 +8,66 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
   describe "finding business support editions" do
     before do
       @artefact = FactoryGirl.create(:artefact, :live)
-      @ed1 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :priority => 1,
-                                :short_description => "Alpha desc",
-                                :areas => ['1','666','999'],
-                                :business_sizes => ['up-to-249'],
-                                :locations => ['scotland','england'],
-                                :sectors => ['manufacturing','utilities'],
-                                :state => 'published')
-      @ed2 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :priority => 2,
-                                :short_description => "Bravo desc",
-                                :areas => ['45','444','666'],
-                                :business_sizes => ['up-to-249'],
-                                :locations => ['scotland', 'wales'],
-                                :state => 'published')
-      @ed3 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :priority => 1,
-                                :short_description => "Charlie desc",
-                                :areas => ['1','2','3'],
-                                :business_sizes => ['up-to-1000'],
-                                :purposes => ['world-domination'],
-                                :state => 'published')
-      @ed4 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :priority => 1,
-                                :short_description => "Delta desc",
-                                :locations => ['wales'],
-                                :sectors => ['manufacturing'],
-                                :support_types => ['award','loan'],
-                                :review_requested_at => Time.zone.now,
-                                :state => 'in_review')
-      @ed5 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :priority => 1,
-                                :short_description => "Echo desc",
-                                :areas => ['9','666'],
-                                :business_sizes => ['up-to-249'],
-                                :locations => ['england'],
-                                :support_types => ['grant','loan'],
-                                :state => 'published')
-      @ed6 = FactoryGirl.create(:business_support_edition,
-                                :panopticon_id => @artefact._id,
-                                :short_description => "Fox-trot desc",
-                                :locations => ['scotland', 'wales'],
-                                :state => 'archived')
+      @ed1 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :priority => 1,
+        :short_description => "Alpha desc",
+        :areas => ['1','666','999'],
+        :business_sizes => ['up-to-249'],
+        :locations => ['scotland','england'],
+        :sectors => ['manufacturing','utilities'],
+        :state => 'published',
+      )
+      @ed2 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :priority => 2,
+        :short_description => "Bravo desc",
+        :areas => ['45','444','666'],
+        :business_sizes => ['up-to-249'],
+        :locations => ['scotland', 'wales'],
+        :state => 'published',
+      )
+      @ed3 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :priority => 1,
+        :short_description => "Charlie desc",
+        :areas => ['1','2','3'],
+        :business_sizes => ['up-to-1000'],
+        :purposes => ['world-domination'],
+        :state => 'published',
+      )
+      @ed4 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :priority => 1,
+        :short_description => "Delta desc",
+        :locations => ['wales'],
+        :sectors => ['manufacturing'],
+        :support_types => ['award','loan'],
+        :review_requested_at => Time.zone.now,
+        :state => 'in_review',
+      )
+      @ed5 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :priority => 1,
+        :short_description => "Echo desc",
+        :areas => ['9','666'],
+        :business_sizes => ['up-to-249'],
+        :locations => ['england'],
+        :support_types => ['grant','loan'],
+        :state => 'published',
+      )
+      @ed6 = FactoryGirl.create(
+        :business_support_edition,
+        :panopticon_id => @artefact._id,
+        :short_description => "Fox-trot desc",
+        :locations => ['scotland', 'wales'],
+        :state => 'archived',
+      )
     end
 
     it "should return all matching business support editions" do

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -13,7 +13,11 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Alpha desc",
-        :areas => ['1','666','999'],
+        :areas => [
+          'west-sussex-county-council',
+          'devon-county-council',
+          'wycombe-district-council',
+        ],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland','england'],
         :sectors => ['manufacturing','utilities'],
@@ -24,7 +28,11 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 2,
         :short_description => "Bravo desc",
-        :areas => ['45','444','666'],
+        :areas => [
+          'south-bucks-district-council',
+          'london',
+          'devon-county-council',
+        ],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland', 'wales'],
         :state => 'published',
@@ -34,7 +42,11 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Charlie desc",
-        :areas => ['1','2','3'],
+        :areas => [
+          'west-sussex-county-council',
+          'scotland',
+          'hackney-borough-council',
+        ],
         :business_sizes => ['up-to-1000'],
         :purposes => ['world-domination'],
         :state => 'published',
@@ -55,7 +67,10 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Echo desc",
-        :areas => ['9','666'],
+        :areas => [
+          'camden-borough-council',
+          'devon-county-council',
+        ],
         :business_sizes => ['up-to-249'],
         :locations => ['england'],
         :support_types => ['grant','loan'],
@@ -71,7 +86,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
     end
 
     it "should return all matching business support editions" do
-      get "/business_support_schemes.json?areas=666&business_sizes=up-to-249&locations=england,wales"
+      get "/business_support_schemes.json?areas=devon-county-council&business_sizes=up-to-249&locations=england,wales"
       assert_status_field "ok", last_response
 
       parsed_response = JSON.parse(last_response.body)

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -18,6 +18,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
           'devon-county-council',
           'wycombe-district-council',
         ],
+        :area_gss_codes => ['E10000032', 'E10000008', 'E07000007'],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland','england'],
         :sectors => ['manufacturing','utilities'],
@@ -33,6 +34,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
           'london',
           'devon-county-council',
         ],
+        :area_gss_codes => ['E07000006', 'E15000007', 'E10000008'],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland', 'wales'],
         :state => 'published',
@@ -47,6 +49,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
           'scotland',
           'hackney-borough-council',
         ],
+        :area_gss_codes => ['E10000032', 'S15000001', 'E09000012'],
         :business_sizes => ['up-to-1000'],
         :purposes => ['world-domination'],
         :state => 'published',
@@ -71,6 +74,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
           'camden-borough-council',
           'devon-county-council',
         ],
+        :area_gss_codes => ['E09000007', 'E10000008'],
         :business_sizes => ['up-to-249'],
         :locations => ['england'],
         :support_types => ['grant','loan'],
@@ -92,6 +96,17 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
       parsed_response = JSON.parse(last_response.body)
       assert_equal 3, parsed_response["total"]
       assert_equal ['Alpha desc', 'Bravo desc', 'Echo desc'], parsed_response["results"].map {|r| r["short_description"] }.sort
+    end
+
+    describe "querying by GSS code" do
+      it "should return all matching business support editions" do
+        get "/business_support_schemes.json?area_gss_codes=E10000008"
+        assert_status_field "ok", last_response
+
+        parsed_response = JSON.parse(last_response.body)
+        assert_equal 3, parsed_response["total"]
+        assert_equal ['Alpha desc', 'Bravo desc', 'Echo desc'], parsed_response["results"].map {|r| r["short_description"] }.sort
+      end
     end
 
     it "should return basic artefact details for each result when queried by facets" do


### PR DESCRIPTION
We're working on removing Business Support Scheme's dependence on 'area slugs' in favour of referring to areas by their (more stable) GSS codes (http://www.ons.gov.uk/ons/guide-method/geography/products/names--codes-and-look-ups/standard-names-and-codes/index.html).

Since the migration to GSS codes involves multiple applications and gems, we've decided to first add the GSS codes to the existing Business Support data, then think about removing the current area slugs after.

The change in this pull request enables querying Business Support Schemes by `area_gss_codes` alongside `areas`. Once the applications that use this endpoint have been moved over to GSS codes, the ability to query by slugified area names will be removed.

The story is https://trello.com/c/XsykRbHp/45-publisher-and-business-support-api-should-use-gss-codes.