### PR TITLE
Remove `areas` facet from Business Support Schemes

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -367,7 +367,7 @@ class GovUkContentApi < Sinatra::Application
     set_expiry
 
     facets = {}
-    [:areas, :area_gss_codes, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
+    [:area_gss_codes, :business_sizes, :locations, :purposes, :sectors, :stages, :support_types].each do |key|
       facets[key] = params[key] if params[key].present?
     end
 

--- a/lib/presenters/business_support_scheme_presenter.rb
+++ b/lib/presenters/business_support_scheme_presenter.rb
@@ -11,7 +11,6 @@ class BusinessSupportSchemePresenter
 
     base_presenter.present.merge({
       "short_description" => @artefact.edition.short_description,
-      "areas" => @artefact.edition.areas,
       "area_gss_codes" => @artefact.edition.area_gss_codes,
       "business_sizes" => @artefact.edition.business_sizes,
       "locations" => @artefact.edition.locations,

--- a/test/requests/business_support_schemes_test.rb
+++ b/test/requests/business_support_schemes_test.rb
@@ -13,11 +13,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Alpha desc",
-        :areas => [
-          'west-sussex-county-council',
-          'devon-county-council',
-          'wycombe-district-council',
-        ],
         :area_gss_codes => ['E10000032', 'E10000008', 'E07000007'],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland','england'],
@@ -29,11 +24,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 2,
         :short_description => "Bravo desc",
-        :areas => [
-          'south-bucks-district-council',
-          'london',
-          'devon-county-council',
-        ],
         :area_gss_codes => ['E07000006', 'E15000007', 'E10000008'],
         :business_sizes => ['up-to-249'],
         :locations => ['scotland', 'wales'],
@@ -44,11 +34,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Charlie desc",
-        :areas => [
-          'west-sussex-county-council',
-          'scotland',
-          'hackney-borough-council',
-        ],
         :area_gss_codes => ['E10000032', 'S15000001', 'E09000012'],
         :business_sizes => ['up-to-1000'],
         :purposes => ['world-domination'],
@@ -70,10 +55,6 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
         :panopticon_id => @artefact._id,
         :priority => 1,
         :short_description => "Echo desc",
-        :areas => [
-          'camden-borough-council',
-          'devon-county-council',
-        ],
         :area_gss_codes => ['E09000007', 'E10000008'],
         :business_sizes => ['up-to-249'],
         :locations => ['england'],
@@ -90,7 +71,7 @@ class BusinessSupportSchemesTest < GovUkContentApiTest
     end
 
     it "should return all matching business support editions" do
-      get "/business_support_schemes.json?areas=devon-county-council&business_sizes=up-to-249&locations=england,wales"
+      get "/business_support_schemes.json?business_sizes=up-to-249&locations=england,wales"
       assert_status_field "ok", last_response
 
       parsed_response = JSON.parse(last_response.body)


### PR DESCRIPTION
We're working on removing Business Support Scheme's dependence on 'area slugs' in favour of referring to areas by their (more stable) GSS codes (http://www.ons.gov.uk/ons/guide-method/geography/products/names--codes-and-look-ups/standard-names-and-codes/index.html).

Since the migration to GSS codes involves multiple applications and gems, we first added the GSS codes to the existing Business Support data, and are only now removing the area slugs.

NOTE: These changes should be deployed after https://github.com/alphagov/business-support-api/pull/32. Once that's done, Business Support API will use GSS codes (the `area_gss_codes` facet) to query for Business Support Schemes, negating any need for the `areas` facet.

The story is https://trello.com/c/XsykRbHp/45-publisher-and-business-support-api-should-use-gss-codes.