### PR TITLE
Add a taggings-per-app endpoint

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -24,6 +24,7 @@ require "presenters/licence_presenter"
 require "presenters/tagged_artefact_presenter"
 require "presenters/grouped_result_set_presenter"
 require "govspeak_formatter"
+require "taggings_per_app"
 
 # Note: the artefact patch needs to be included before the Kaminari patch,
 # otherwise it doesn't work. I haven't quite got to the bottom of why that is.
@@ -477,6 +478,10 @@ class GovUkContentApi < Sinatra::Application
         mainstream_browse_page_slugs: artefact.tags.select { |tag| tag.tag_type == 'section' }.map(&:tag_id)
       }
     end.to_json
+  end
+
+  get '/debug/taggings-per-app.json' do
+    TaggingsPerApp.new(params.fetch('app')).taggings.to_json
   end
 
   get "/*.json" do |id|

--- a/lib/taggings_per_app.rb
+++ b/lib/taggings_per_app.rb
@@ -1,0 +1,50 @@
+# TaggingsPerApp
+#
+# Debug helper to aid with the tagging migration. It outputs the taggings for
+# a specific app in a hash like:
+#
+#   { "content_id" => { "mainstream_browse_pages" => ["content_id"]}}
+#
+class TaggingsPerApp
+  # Mapping between the old name used by content_api and the new tag name used
+  # in the new publishing world.
+  MAP = {
+    "section" => "mainstream_browse_pages",
+    "organisation" => "organisations",
+    "specialist_sector" => "topics",
+  }
+
+  def initialize(app_name)
+    @app_name = app_name
+  end
+
+  def taggings
+    relevant_artefacts.each_with_object({}) do |artefact, result|
+      result[artefact.content_id] = tags_for_artefact(artefact)
+    end
+  end
+
+private
+
+  def relevant_artefacts
+    Artefact.live.where(owning_app: @app_name, :content_id.nin => [nil])
+  end
+
+  def tags_for_artefact(artefact)
+    hash = {}
+
+    artefact.tags.map do |tag|
+      next unless tag.tag_type.in?(MAP.keys)
+
+      new_type = MAP.fetch(tag.tag_type)
+      hash[new_type] ||= []
+      hash[new_type] << tag.content_id
+    end
+
+    if artefact.primary_section
+      hash["parent"] = [artefact.primary_section.content_id]
+    end
+
+    hash
+  end
+end

--- a/test/unit/taggings_per_app_test.rb
+++ b/test/unit/taggings_per_app_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+describe TaggingsPerApp do
+  describe "#taggings" do
+    it "returns the tags in a useful format" do
+      FactoryGirl.create(:live_artefact, owning_app: 'publisher')
+      artefact = FactoryGirl.create(:live_artefact, owning_app: 'smartanswers', content_id: '26e3bd4d-c0e8-4256-b417-6488f356ab89')
+
+      tag = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "a-tag-id", content_id: "03aded93-677f-4061-8024-d4a4c55b2fea")
+      artefact.set_tags_of_type("section", ["a-tag-id"])
+      artefact.save
+
+      taggings = TaggingsPerApp.new('smartanswers').taggings
+
+      assert_equal({
+        "26e3bd4d-c0e8-4256-b417-6488f356ab89" => {
+          "mainstream_browse_pages" => ["03aded93-677f-4061-8024-d4a4c55b2fea"],
+          "parent" => ["03aded93-677f-4061-8024-d4a4c55b2fea"]
+        }
+      }, taggings)
+    end
+  end
+end


### PR DESCRIPTION
/debug/taggings-per-app.json is a temporary endpoint which will be used to compare the taggings in panopti(con)tentapi with the taggings in the content-store.

This will aid us in the migration and will allow us to be confident that we haven't inadvertently removed any tagging.

Trello: https://trello.com/c/DLakGcP0
On content-store: https://github.com/alphagov/content-store/pull/170