### PR TITLE
Add homepage_url to JSON representation of LocalAuthority

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '3.2.22'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 32.1'
+  gem "govuk_content_models", '~> 32.2'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (32.1.0)
+    govuk_content_models (32.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -246,7 +246,7 @@ DEPENDENCIES
   gds-api-adapters (= 26.7.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
-  govuk_content_models (~> 32.1)
+  govuk_content_models (~> 32.2)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (= 3.4.0)

--- a/lib/presenters/local_authority_presenter.rb
+++ b/lib/presenters/local_authority_presenter.rb
@@ -2,6 +2,7 @@ class LocalAuthorityPresenter
 
   FIELDS = %w(
     name snac tier contact_address contact_url contact_phone contact_email
+    homepage_url
   )
 
   def initialize(result, url_helper)

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -355,9 +355,16 @@ class ArtefactRequestTest < GovUkContentApiTest
         end
 
         it "should return local service, local authority and local interaction details" do
-          authority = FactoryGirl.create(:local_authority)
-          interaction = FactoryGirl.create(:local_interaction, lgsl_code: @service.lgsl_code,
-            local_authority: authority)
+          authority = FactoryGirl.create(
+            :local_authority,
+            homepage_url: 'http://council.example.gov/',
+            contact_url: 'http://council.example.gov/get-in-touch',
+          )
+          interaction = FactoryGirl.create(
+            :local_interaction,
+            lgsl_code: @service.lgsl_code,
+            local_authority: authority
+          )
 
           get "/#{@local_transaction_edition.artefact.slug}.json?snac=#{authority.snac}"
           assert last_response.ok?
@@ -366,6 +373,8 @@ class ArtefactRequestTest < GovUkContentApiTest
           assert_equal @service.lgsl_code, response['details']['local_service']['lgsl_code']
           assert_equal @service.providing_tier, response['details']['local_service']['providing_tier']
           assert_equal authority.name, response['details']['local_authority']['name']
+          assert_equal 'http://council.example.gov/', response['details']['local_authority']['homepage_url']
+          assert_equal 'http://council.example.gov/get-in-touch', response['details']['local_authority']['contact_url']
           assert_equal interaction.url, response['details']['local_interaction']['url']
         end
 

--- a/test/requests/local_authority_request_test.rb
+++ b/test/requests/local_authority_request_test.rb
@@ -81,9 +81,10 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
       snac: "00CT",
       tier: "unitary",
       contact_address: ["123 Fake Street"],
-      contact_url: "http://council.gov.uk",
+      contact_url: "http://council.gov.uk/get-in-touch",
       contact_phone: "01234 567890",
-      contact_email: "cousin.sven@council.gov.uk"
+      contact_email: "cousin.sven@council.gov.uk",
+      homepage_url: "http://council.gov.uk",
     }
 
     stub_results = [LocalAuthority.new(attributes),
@@ -99,9 +100,10 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
                   "id" => "http://example.org/local_authorities/00CT.json",
                   "tier" => "unitary",
                   "contact_address" => ["123 Fake Street"],
-                  "contact_url" => "http://council.gov.uk",
+                  "contact_url" => "http://council.gov.uk/get-in-touch",
                   "contact_phone" => "01234 567890",
-                  "contact_email" => "cousin.sven@council.gov.uk"
+                  "contact_email" => "cousin.sven@council.gov.uk",
+                  "homepage_url" => 'http://council.gov.uk',
                 },
                 {
                   "name" => "Solihull Council",
@@ -109,9 +111,10 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
                   "id" => "http://example.org/local_authorities/00VT.json",
                   "tier" => "unitary",
                   "contact_address" => ["123 Fake Street"],
-                  "contact_url" => "http://council.gov.uk",
+                  "contact_url" => "http://council.gov.uk/get-in-touch",
                   "contact_phone" => "01234 567890",
-                  "contact_email" => "cousin.sven@council.gov.uk"
+                  "contact_email" => "cousin.sven@council.gov.uk",
+                  "homepage_url" => 'http://council.gov.uk',
                 }]
 
     assert last_response.ok?


### PR DESCRIPTION
This is the final part of the puzzle for https://trello.com/c/td7NzjPG/261-use-local-authority-home-page-url-when-we-don-t-have-a-matching-transaction

1. After adding homepage_url to LocalAuthority (https://github.com/alphagov/govuk_content_models/pull/356)
2. And importing it from local.direct.gov in publisher (https://github.com/alphagov/publisher/pull/443)
3. In order to use it in frontend (https://github.com/alphagov/frontend/pull/914)
4. We need to put it into the JSON representation provided by this API

This PR does that.