### PR TITLE
Update govuk_content_models to 34.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '3.2.22'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 32.2'
+  gem "govuk_content_models", '~> 34.0.0'
 end
 
 # TODO: This was previously pinned due to a replica set bug in >1.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (32.2.0)
+    govuk_content_models (34.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -246,7 +246,7 @@ DEPENDENCIES
   gds-api-adapters (= 28.2.1)
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
-  govuk_content_models (~> 32.2)
+  govuk_content_models (~> 34.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (= 3.4.0)


### PR DESCRIPTION
Part of: https://trello.com/c/ODNdKlkp/564-remove-legacy-source-from-panopticon