### PR TITLE
Add start button text to the OPTIONAL_FIELDS list

### DIFF
--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -20,6 +20,7 @@ class ArtefactPresenter
     alert_status
     alternate_methods
     body
+    start_button_text
     change_description
     continuation_link
     department_analytics_profile


### PR DESCRIPTION
As requested in this [Trello card](https://trello.com/c/CUe4odRB/45-make-start-now-editable-in-simple-smart-answers), the need to add the capability to change the text of the start button for simple smart answers.

Here, I have added to the ArtefactPresenter 's OPTIONAL_FIELDS  list "start_button_text"


Related PRs
* [Publisher](https://github.com/alphagov/publisher/pull/474)
* [Content Models](https://github.com/alphagov/govuk_content_models/pull/383)
* [Frontend](https://github.com/alphagov/frontend/pull/950)

SEE Trello ticket

![screen shot 2016-05-03 at 16 41 13](https://cloud.githubusercontent.com/assets/84896/14989058/f3de416e-114d-11e6-81c3-4608510997df.png)