### PR TITLE
Add conditionals to questions in simple smart answers

### DIFF
--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -150,6 +150,13 @@ private
             "label" => o.label,
             "slug" => o.slug,
             "next_node" => o.next_node,
+            "conditions" => o.conditions.map { |c|
+              {
+                "label" => c.label,
+                "slug" => c.slug,
+                "next_node" => c.next_node
+              }
+            }
           }
         }
       }

--- a/test/requests/formats_request_test.rb
+++ b/test/requests/formats_request_test.rb
@@ -434,27 +434,35 @@ class FormatsRequestTest < GovUkContentApiTest
   end
 
   it "should work with simple smart-answers" do
-    artefact = FactoryGirl.create(:artefact, :slug => 'the-bridge-of-death', :owning_app => 'publisher', :state => 'live')
-    smart_answer = FactoryGirl.build(:simple_smart_answer_edition, :panopticon_id => artefact.id, :state => 'published',
-                        :body => "STOP!\n-----\n\nHe who would cross the Bridge of Death  \nMust answer me  \nThese questions three  \nEre the other side he see.\n")
+    artefact = FactoryGirl.create(:artefact, slug: 'the-bridge-of-death', owning_app: 'publisher', state: 'live')
+    smart_answer = FactoryGirl.build(:simple_smart_answer_edition, panopticon_id: artefact.id, state: 'published',
+                        body: "STOP!\n-----\n\nHe who would cross the Bridge of Death  \nMust answer me  \nThese questions three  \nEre the other side he see.\n")
 
-    n = smart_answer.nodes.build(:kind => 'question', :slug => 'what-is-your-name', :title => "What is your name?", :order => 1)
-    n.options.build(:label => "Sir Lancelot of Camelot", :next_node => 'what-is-your-favorite-colour', :order => 1)
-    n.options.build(:label => "Sir Galahad of Camelot", :next_node => 'what-is-your-favorite-colour', :order => 3)
-    n.options.build(:label => "Sir Robin of Camelot", :next_node => 'what-is-the-capital-of-assyria', :order => 2)
+    n = smart_answer.nodes.build(kind: 'question', slug: 'what-is-your-name', title: "What is your name?", order: 1)
+    n.options.build(label: "Sir Lancelot of Camelot", next_node: 'what-is-your-favorite-colour', order: 1)
+    n.options.build(label: "Sir Galahad of Camelot", next_node: 'what-is-your-favorite-colour', order: 3)
+    n.options.build(label: "Sir Robin of Camelot", next_node: 'what-is-the-capital-of-assyria', order: 2)
 
-    n = smart_answer.nodes.build(:kind => 'question', :slug => 'what-is-your-favorite-colour', :title => "What is your favorite colour?", :order => 3)
-    blue_condition_lancelot = { slug: 'what-is-your-name', label: "Sir Lancelot of Camelot", next_node: 'right-off-you-go'}
-    blue_condition_galahad = { slug: 'what-is-your-name', label: "Sir Galahad of Camelot", next_node: 'go-defend-the-realm'}
-    n.options.build(:label => "Blue", :conditions => [blue_condition_lancelot, blue_condition_galahad])
-    n.options.build(:label => "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", :next_node => 'arrrrrghhhh')
+    n = smart_answer.nodes.build(kind: 'question', slug: 'what-is-your-favorite-colour', title: "What is your favorite colour?", order: 3)
+    blue_condition_lancelot = {
+      slug: 'what-is-your-name',
+      label: "Sir Lancelot of Camelot",
+      next_node: 'right-off-you-go'
+    }
+    blue_condition_galahad = {
+      slug: 'what-is-your-name',
+      label: "Sir Galahad of Camelot",
+      next_node: 'go-defend-the-realm'
+    }
+    n.options.build(label: "Blue", conditions: [blue_condition_lancelot, blue_condition_galahad])
+    n.options.build(label: "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", next_node: 'arrrrrghhhh')
 
-    n = smart_answer.nodes.build(:kind => 'question', :slug => 'what-is-the-capital-of-assyria', :title => "What is the capital of Assyria?", :order => 2)
-    n.options.build(:label => "I don't know THAT!!", :next_node => 'arrrrrghhhh')
+    n = smart_answer.nodes.build(kind: 'question', slug: 'what-is-the-capital-of-assyria', title: "What is the capital of Assyria?", order: 2)
+    n.options.build(label: "I don't know THAT!!", next_node: 'arrrrrghhhh')
 
-    n = smart_answer.nodes.build(:kind => 'outcome', :slug => 'right-off-you-go', :title => "Right, off you go.", :body => "Oh! Well, thank you.  Thank you very much", :order => 4)
-    n = smart_answer.nodes.build(:kind => 'outcome', :slug => 'arrrrrghhhh', :title => "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!", :order => 5)
-    n = smart_answer.nodes.build(:kind => 'outcome', :slug => 'go-defend-the-realm', :title => "Go and defend the realm", :order => 6)
+    smart_answer.nodes.build(kind: 'outcome', slug: 'right-off-you-go', title: "Right, off you go.", body: "Oh! Well, thank you.  Thank you very much", order: 4)
+    smart_answer.nodes.build(kind: 'outcome', slug: 'arrrrrghhhh', title: "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!", order: 5)
+    smart_answer.nodes.build(kind: 'outcome', slug: 'go-defend-the-realm', title: "Go and defend the realm", order: 6)
     smart_answer.save!
 
     get '/the-bridge-of-death.json'
@@ -469,31 +477,37 @@ class FormatsRequestTest < GovUkContentApiTest
 
     nodes = details["nodes"]
 
-    assert_equal ["What is your name?", "What is the capital of Assyria?", "What is your favorite colour?", "Right, off you go.", "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!", "Go and defend the realm"], nodes.map {|n| n["title"]}
+    assert_equal [
+      "What is your name?",
+      "What is the capital of Assyria?",
+      "What is your favorite colour?",
+      "Right, off you go.", "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!",
+      "Go and defend the realm"
+      ], nodes.map { |node| node["title"] }
 
     question1 = nodes[0]
     assert_equal "question", question1["kind"]
     assert_equal "what-is-your-name", question1["slug"]
-    assert_equal ["Sir Lancelot of Camelot", "Sir Robin of Camelot", "Sir Galahad of Camelot"], question1["options"].map {|o| o["label"]}
-    assert_equal ["sir-lancelot-of-camelot", "sir-robin-of-camelot", "sir-galahad-of-camelot"], question1["options"].map {|o| o["slug"]}
-    assert_equal ["what-is-your-favorite-colour", "what-is-the-capital-of-assyria", "what-is-your-favorite-colour"], question1["options"].map {|o| o["next_node"]}
+    assert_equal ["Sir Lancelot of Camelot", "Sir Robin of Camelot", "Sir Galahad of Camelot"], question1["options"].map { |o| o["label"] }
+    assert_equal ["sir-lancelot-of-camelot", "sir-robin-of-camelot", "sir-galahad-of-camelot"], question1["options"].map { |o| o["slug"] }
+    assert_equal ["what-is-your-favorite-colour", "what-is-the-capital-of-assyria", "what-is-your-favorite-colour"], question1["options"].map { |o| o["next_node"] }
 
     question2 = nodes[2]
     assert_equal "question", question2["kind"]
     assert_equal "what-is-your-favorite-colour", question2["slug"]
 
     q2_conditions_slugs = question2["options"].map do |option|
-      option["conditions"].collect {|condition| condition["slug"]}
+      option["conditions"].collect { |condition| condition["slug"] }
     end
     assert_equal ["what-is-your-name", "what-is-your-name"], q2_conditions_slugs.flatten(1)
 
     q2_conditions_labels = question2["options"].map do |option|
-      option["conditions"].collect {|condition| condition["label"]}
+      option["conditions"].collect { |condition| condition["label"] }
     end
     assert_equal ["Sir Lancelot of Camelot", "Sir Galahad of Camelot"], q2_conditions_labels.flatten(1)
 
     q2_conditions_next_nodes = question2["options"].map do |option|
-      option["conditions"].collect {|condition| condition["next_node"]}
+      option["conditions"].collect { |condition| condition["next_node"] }
     end
     assert_equal ["right-off-you-go", "go-defend-the-realm"], q2_conditions_next_nodes.flatten(1)
 


### PR DESCRIPTION
Trello story: https://trello.com/c/mzoFV27O/44-ability-to-reuse-a-node-in-simple-smart-answers

## Motivation

The current implementation of Simple Smart Answers only allow you to route users depending on how they have answered the current question. It does not take into account the answers to the questions that have come before.

For example.

If users always have to answer Question 2, but you need to direct users to a different outcome in Question 2, based on their answer in Question 1, at the moment you would have to do this:

```
Q1
Yes -> Q2a
No -> Q2b

Q2a
Yes -> Outcome 1
No -> Outcome 3

Q2b
Yes -> Outcome 2
No -> Outcome 4
```

In this scenario Q2a and Q2b are duplicate questions

The aim of this change is to pave the way to allow questions to be defined like this:

```
Q1
Yes -> Q2
No -> Q2

Q2
Yes
    If Q1 = Yes -> Outcome 1
    If Q1 = No -> Outcome 2
No 
    If Q1 = Yes -> Outcome 3
    If Q1 = No  -> Outcome 4
```

## Assumptions

1. A conditional can refer to one previous question and answer.
2. An option can have many conditionals.
3. Removing a condition only removes one condition
4. Removing an option removes all associated conditions

## Dependencies

These changes are dependent upon a [PR 384](https://github.com/alphagov/govuk_content_models/pull/384) in govuk_content_models that adds an optional Condition class to the Option model that allows you define the next_node in the flow based on the answer to a previous question.

## Changes

Update the API to accept a list of conditions in the options field of node in simple smart answers.