### PR TITLE
Set cache time for local authority with snac

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -93,6 +93,7 @@ class GovUkContentApi < Sinatra::Application
   end
 
   get "/local_authorities/:snac.json" do
+    set_expiry LONG_CACHE_TIME
     custom_410
   end
 

--- a/test/requests/local_authority_request_test.rb
+++ b/test/requests/local_authority_request_test.rb
@@ -12,4 +12,16 @@ class LocalAuthorityRequestTest < GovUkContentApiTest
     assert_equal 410, last_response.status
     assert_status_field "gone", last_response
   end
+
+  describe "setting cache-control headers" do
+    it "should set long cache-control headers if no name or snac code is provided" do
+      get "/local_authorities.json"
+      assert_equal "public, max-age=#{1.hour.to_i}", last_response.headers["Cache-control"]
+    end
+
+    it "should set long cache-control headers for a snac lookup" do
+      get "/local_authorities/00CT.json"
+      assert_equal "public, max-age=#{1.hour.to_i}", last_response.headers["Cache-control"]
+    end
+  end
 end

--- a/test/requests/local_authority_request_test.rb
+++ b/test/requests/local_authority_request_test.rb
@@ -1,25 +1,27 @@
 require "test_helper"
 
 class LocalAuthorityRequestTest < GovUkContentApiTest
-  it "should return 410 if no name or snac code is provided" do
-    get "/local_authorities.json"
-    assert_equal 410, last_response.status
-    assert_status_field "gone", last_response
-  end
+  describe "local authorities index URL" do
+    it "should return 410" do
+      get "/local_authorities.json"
+      assert_equal 410, last_response.status
+      assert_status_field "gone", last_response
+    end
 
-  it "should return 410 if a snac code is provided" do
-    get "/local_authorities/gobble_de_gook.json"
-    assert_equal 410, last_response.status
-    assert_status_field "gone", last_response
-  end
-
-  describe "setting cache-control headers" do
-    it "should set long cache-control headers if no name or snac code is provided" do
+    it "should set long cache-control headers" do
       get "/local_authorities.json"
       assert_equal "public, max-age=#{1.hour.to_i}", last_response.headers["Cache-control"]
     end
+  end
 
-    it "should set long cache-control headers for a snac lookup" do
+  describe "local authorities with SNAC" do
+    it "should return 410" do
+      get "/local_authorities/gobble_de_gook.json"
+      assert_equal 410, last_response.status
+      assert_status_field "gone", last_response
+    end
+
+    it "should set long cache-control headers" do
       get "/local_authorities/00CT.json"
       assert_equal "public, max-age=#{1.hour.to_i}", last_response.headers["Cache-control"]
     end


### PR DESCRIPTION
This was accidentally removed in 190a2cf. Reinstate the tests for the cache headers too, and refactor the tests for this API to describe paths.