### PR TITLE
Stop returning local interactions in api responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '4.2.6'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '37.0.0'
+  gem "govuk_content_models", '38.0.0'
 end
 
 gem 'gds-sso', '~> 11.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     govuk-lint (0.8.1)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_content_models (37.0.0)
+    govuk_content_models (38.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -140,7 +140,7 @@ GEM
       ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    mongo (2.2.5)
+    mongo (2.2.7)
       bson (~> 4.0)
     mongoid (5.1.3)
       activemodel (~> 4.0)
@@ -306,7 +306,7 @@ DEPENDENCIES
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
   govuk-lint
-  govuk_content_models (= 37.0.0)
+  govuk_content_models (= 38.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (~> 5.0)

--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -682,12 +682,6 @@ protected
   def attach_local_information(artefact, snac)
     provider = artefact.edition.service.preferred_provider(snac)
     artefact.local_authority = provider
-    if provider
-      artefact.local_interaction = provider.preferred_interaction_for(
-        artefact.edition.lgsl_code,
-        artefact.edition.lgil_override
-      )
-    end
   end
 
   def asset_manager_api

--- a/lib/artefact.rb
+++ b/lib/artefact.rb
@@ -15,7 +15,6 @@ module ContentApiArtefactExtensions
       :extra_tags,
       :group,
       :local_authority,
-      :local_interaction
     )
     scope :live, -> { where(state: 'live') }
   end

--- a/lib/presenters/artefact_presenter.rb
+++ b/lib/presenters/artefact_presenter.rb
@@ -83,7 +83,6 @@ class ArtefactPresenter
       places,
       licence,
       local_authority,
-      local_interaction,
       local_service,
       assets,
       country,
@@ -192,18 +191,6 @@ private
 
     presenter = LocalAuthorityPresenter.new(@artefact.local_authority)
     { "local_authority" => presenter.present }
-  end
-
-  def local_interaction
-    return {} unless @artefact.local_interaction
-
-    {
-      "local_interaction" => {
-        "lgsl_code" => @artefact.local_interaction.lgsl_code,
-        "lgil_code" => @artefact.local_interaction.lgil_code,
-        "url" => @artefact.local_interaction.url
-      }
-    }
   end
 
   def local_service

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -354,15 +354,10 @@ class ArtefactRequestTest < GovUkContentApiTest
           @local_transaction_edition.artefact.update_attribute(:state, 'live')
         end
 
-        it "should return local service, local authority and local interaction details" do
+        it "should return local service and local authority details" do
           authority = FactoryGirl.create(
             :local_authority,
             homepage_url: 'http://council.example.gov/',
-          )
-          interaction = FactoryGirl.create(
-            :local_interaction,
-            lgsl_code: @service.lgsl_code,
-            local_authority: authority
           )
 
           get "/#{@local_transaction_edition.artefact.slug}.json?snac=#{authority.snac}"
@@ -373,22 +368,9 @@ class ArtefactRequestTest < GovUkContentApiTest
           assert_equal @service.providing_tier, response['details']['local_service']['providing_tier']
           assert_equal authority.name, response['details']['local_authority']['name']
           assert_equal 'http://council.example.gov/', response['details']['local_authority']['homepage_url']
-          assert_equal interaction.url, response['details']['local_interaction']['url']
         end
 
-        it "should return nil local_interaction when no interaction available" do
-          authority = FactoryGirl.create(:local_authority)
-
-          get "/#{@local_transaction_edition.artefact.slug}.json?snac=#{authority.snac}"
-          assert last_response.ok?
-          response = JSON.parse(last_response.body)
-
-          assert_equal @service.lgsl_code, response['details']['local_service']['lgsl_code']
-          assert_equal authority.name, response['details']['local_authority']['name']
-          assert_nil response['details']['local_interaction']
-        end
-
-        it "should return nil local_interaction and local_authority when no authority available" do
+        it "should return nil local_authority when no authority available" do
 
           get "/#{@local_transaction_edition.artefact.slug}.json?snac=00PT"
           assert last_response.ok?
@@ -396,9 +378,7 @@ class ArtefactRequestTest < GovUkContentApiTest
 
           assert_equal @service.lgsl_code, response['details']['local_service']['lgsl_code']
           assert_nil response['details']['local_authority']
-          assert_nil response['details']['local_interaction']
         end
-
       end
 
       it "should return local_service details for local transactions without snac code" do


### PR DESCRIPTION
For: https://trello.com/c/opAHOMr4/443-4-of-4-delete-old-ldg-import-into-publisher-and-related-code-3

We now store local interaction links in [Local Links
Manager](https://github.com/alphagov/local-links-manager) and use its API
to fetch them in Frontend so we don't need to return them in here any
more.  We leave the artefact+snac endpoint as it may still be useful
to retrieve and artefact with some local authority information (for
licences perhaps?).

Assumes that we're using the version of govuk_content_models that has alphagov/govuk_content_models#389 merged in.