### PR TITLE
Remove rescuing of all Licensify errors

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -602,8 +602,6 @@ protected
     end
   rescue GdsApi::TimedOutException
     artefact.licence = { "error" => "timed_out" }
-  rescue GdsApi::HTTPErrorResponse
-    artefact.licence = { "error" => "http_error" }
   rescue => e
     Airbrake.notify_or_ignore(e)
     artefact.licence = { "error" => "http_error" }


### PR DESCRIPTION
The rescue immediately below this does exactly the same thing but is more useful because it notifies Errbit.