### PR TITLE
Bump content models to 41.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '4.2.6'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '40.0.0'
+  gem "govuk_content_models", '41.0.0'
 end
 
 gem 'gds-sso', '~> 11.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_content_models (40.0.0)
+    govuk_content_models (41.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -305,7 +305,7 @@ DEPENDENCIES
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
   govuk-lint
-  govuk_content_models (= 40.0.0)
+  govuk_content_models (= 41.0.0)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (~> 5.0)


### PR DESCRIPTION
As a result of the release of the start button attribute, this PR updates the content model's gem version

This is related to #242 