### PR TITLE
Remove special-casing for travel-advice

### DIFF
--- a/lib/presenters/basic_artefact_presenter.rb
+++ b/lib/presenters/basic_artefact_presenter.rb
@@ -21,15 +21,8 @@ class BasicArtefactPresenter
 private
   # Returns the updated date that should be presented to the user
   def presented_updated_date
-    if @artefact.kind == 'travel-advice'
-      # For travel_advice there's an explicit public publish date.
-      # (Fallback to updated_at if it's missing - either previewing a draft, or old data)
-      @artefact.edition.published_at || @artefact.edition.updated_at
-    else
-      # For everything else, the latest updated_at of the artefact or edition
-      updated_options = [@artefact.updated_at]
-      updated_options << @artefact.edition.updated_at if @artefact.edition
-      updated_options.compact.max
-    end
+    updated_options = [@artefact.updated_at]
+    updated_options << @artefact.edition.updated_at if @artefact.edition
+    updated_options.compact.max
   end
 end


### PR DESCRIPTION
This was supposed to be removed in https://github.com/alphagov/govuk_content_api/pull/263, but got missed.