### PR TITLE
Bump govuk_content_models & add `require_dependency`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '4.2.6'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '41.0.0'
+  gem "govuk_content_models", '41.1.1'
 end
 
 gem 'gds-sso', '~> 11.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_content_models (41.0.0)
+    govuk_content_models (41.1.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -140,9 +140,9 @@ GEM
       ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    mongo (2.3.0)
+    mongo (2.3.1)
       bson (~> 4.1)
-    mongoid (5.1.4)
+    mongoid (5.1.5)
       activemodel (~> 4.0)
       mongo (~> 2.1)
       origin (~> 2.2)
@@ -175,7 +175,7 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    origin (2.2.0)
+    origin (2.2.2)
     parser (2.3.1.2)
       ast (~> 2.2)
     pkg-config (1.1.7)
@@ -305,7 +305,7 @@ DEPENDENCIES
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
   govuk-lint
-  govuk_content_models (= 41.0.0)
+  govuk_content_models (= 41.1.1)
   kaminari (= 0.14.1)
   link_header (= 0.0.8)
   minitest (~> 5.0)

--- a/config/initializers/govuk_content_models_hack.rb
+++ b/config/initializers/govuk_content_models_hack.rb
@@ -1,0 +1,4 @@
+# govuk_content_models depends on this Rails method.
+def require_dependency(*args)
+  require(*args)
+end


### PR DESCRIPTION
This bumps `govuk_content_models`.

`require_dependency` is used by govuk_content_models to fix a problem with autoreloading in development. It's a Rails method. To avoid having to import active support entirely, we can just define the method here.

If there are any questions, @whoojemaflip can help.

See https://github.com/alphagov/govuk_content_models/pull/400.