### PR TITLE
Add Airbrake initializer that reads from environment

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,1 +1,6 @@
-# This is overwritten on deploy
+Airbrake.configure do |config|
+  config.api_key = ENV['ERRBIT_API_KEY']
+  config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
+  config.secure = true
+  config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+end


### PR DESCRIPTION
This file is still overwritten on deploy. We'll remove that in https://github.gds/gds/alphagov-deployment/pull/1285.

The actual env var has been set in https://github.com/alphagov/govuk-puppet/pull/5017 and https://github.gds/gds/deployment/pull/1134.

https://trello.com/c/XyF34nxX