### PR TITLE
Use env vars for rack cache and airbrake config

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -39,14 +39,16 @@ end
 enable :dump_errors, :raise_errors
 
 if ! in_development || ENV["API_CACHE"]
-  cache_config_file_path = File.expand_path(
-    "rack-cache.yml",
-    File.dirname(__FILE__)
-  )
-  if File.exists? cache_config_file_path
-    use Rack::Cache, YAML.load_file(cache_config_file_path).symbolize_keys
+  metastore_conf = ENV["MEMCACHED_METASTORE"]
+  entitystore_conf = ENV["MEMCACHED_ENTITYSTORE"]
+
+  if metastore_conf && entitystore_conf
+    use Rack::Cache,
+      verbose: true,
+      metastore: metastore_conf,
+      entitystore: entitystore_conf
   else
-    warn "Cache config file does not exist: #{cache_config_file_path}"
+    warn "Cache config MEMCACHED_METASTORE, MEMCACHED_ENTITYSTORE not set in env."
   end
 end
 


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline
`Rack::Cache` config is stored in ENV vars now so use them.
See
https://github.com/alphagov/govuk-puppet/pull/5092/commits/07d65cf1a375b8712a548a77c0393372af76bd5d

Depends on https://github.com/alphagov/govuk-puppet/pull/5092