### PR TITLE
Use bearer token for Asset Manager

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -24,6 +24,7 @@ require "govspeak_formatter"
 require 'artefact'
 require 'config/kaminari'
 require 'country'
+require 'services'
 
 class GovUkContentApi < Sinatra::Application
   helpers GdsApi::Helpers
@@ -357,20 +358,13 @@ protected
       asset_id = artefact.edition.send("#{key}_id")
       if asset_id
         begin
-          asset = asset_manager_api.asset(asset_id)
+          asset = Services.asset_manager.asset(asset_id)
           artefact.assets[key] = asset if asset && asset["state"] == "clean"
         rescue GdsApi::BaseError => e
           logger.warn "Requesting asset #{asset_id} returned error: #{e.inspect}"
         end
       end
     end
-  end
-
-  def asset_manager_api
-    options = Object::const_defined?(:ASSET_MANAGER_API_CREDENTIALS) ? ASSET_MANAGER_API_CREDENTIALS : {
-      bearer_token: ENV['CONTENTAPI_ASSET_MANAGER_BEARER_TOKEN']
-    }
-    super(options)
   end
 
   def custom_404

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,8 @@
+module Services
+  def self.asset_manager
+    @asset_manager ||= GdsApi::AssetManager.new(
+      Plek.current.find('asset-manager'),
+      bearer_token: ENV['ASSET_MANAGER_BEARER_TOKEN']
+    )
+  end
+end

--- a/test/requests/travel_advice_test.rb
+++ b/test/requests/travel_advice_test.rb
@@ -244,30 +244,6 @@ class TravelAdviceTest < GovUkContentApiTest
         refute parsed_response["details"].has_key?("document")
       end
 
-      it "should authenticate with asset-manager if configured" do
-        # rubocop:disable MutableConstant
-        ::ASSET_MANAGER_API_CREDENTIALS = { bearer_token: "foobar" }
-        # rubocop:enable MutableConstant
-
-        GovUkContentApi.instance_variable_set('@asset_manager_api', nil)
-
-        FactoryGirl.create(:artefact, slug: 'foreign-travel-advice/aruba', state: 'live',
-                                      kind: 'travel-advice', owning_app: 'travel-advice-publisher')
-        FactoryGirl.create(:published_travel_advice_edition, country_slug: 'aruba',
-                                     image_id: "512c9019686c82191d000003")
-
-        asset_manager_has_an_asset("512c9019686c82191d000003", "id" => "https://asset-manager.production.alphagov.co.uk/assets/512c9019686c82191d000003",
-          "name" => "darth-on-a-cat.jpg",
-          "content_type" => "image/jpeg",
-          "file_url" => "https://assets.digital.cabinet-office.gov.uk/media/512c9019686c82191d000003/darth-on-a-cat.jpg",
-          "state" => "clean",)
-
-        get '/foreign-travel-advice/aruba.json'
-        assert last_response.ok?
-
-        assert_requested(:get, %r{\A#{ASSET_MANAGER_ENDPOINT}}, headers: { "Authorization" => "Bearer foobar" })
-      end
-
       it "should not include details if asset manager is unavailable or returns an error" do
         FactoryGirl.create(:artefact, slug: 'foreign-travel-advice/aruba', state: 'live',
                                       kind: 'travel-advice', owning_app: 'travel-advice-publisher')


### PR DESCRIPTION
This variable is now set in puppet.

Uses the `Services` pattern instead of `GdsApi::Helpers`.

cc @steventux 