### PR TITLE
Fix oauth environment credentials for GDS::SSO

### DIFF
--- a/config/gds_sso_config.rb
+++ b/config/gds_sso_config.rb
@@ -1,6 +1,6 @@
 ::GDS::SSO.config do |config|
   config.user_model     = "ReadOnlyUser"
-  config.oauth_id       = ENV['CONTENTAPI_OAUTH_ID'] || 'abcdefghjasndjkasndcontentapi'
-  config.oauth_secret   = ENV['CONTENTAPI_OAUTH_SECRET'] || 'secret'
+  config.oauth_id       = ENV['OAUTH_ID']
+  config.oauth_secret   = ENV['OAUTH_SECRET']
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
We now configure content api via environment variables. The current configuration is incorrect. This fixes an issue with previewing pages from private-frontend.

https://trello.com/c/XyF34nxX