### PR TITLE
Update gds-api-adapters gem to get the latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'gds-sso', '~> 11.2'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '33.2.2'
+  gem 'gds-api-adapters', '41.2.0'
 end
 
 gem 'govspeak', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     dalli (2.7.4)
     database_cleaner (1.5.1)
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.5.0)
@@ -66,7 +66,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
-    gds-api-adapters (33.2.2)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -105,7 +105,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
@@ -181,7 +181,7 @@ GEM
     pkg-config (1.1.7)
     plek (1.10.0)
     powerpack (0.1.1)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cache (1.2)
@@ -225,7 +225,7 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.4)
       ffi (>= 0.5.0)
-    rest-client (2.0.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -301,7 +301,7 @@ DEPENDENCIES
   dalli (= 2.7.4)
   database_cleaner (= 1.5.1)
   factory_girl (= 4.5.0)
-  gds-api-adapters (= 33.2.2)
+  gds-api-adapters (= 41.2.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.1)
   govuk-lint
@@ -326,4 +326,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.11.2
+   1.14.5


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing