### PR TITLE
Add fallback OAuth ID and secret

### DIFF
--- a/config/gds_sso_config.rb
+++ b/config/gds_sso_config.rb
@@ -1,6 +1,6 @@
-::GDS::SSO.config do |config|
+GDS::SSO.config do |config|
   config.user_model     = "ReadOnlyUser"
-  config.oauth_id       = ENV['OAUTH_ID']
-  config.oauth_secret   = ENV['OAUTH_SECRET']
+  config.oauth_id       = ENV['OAUTH_ID'] || "abcdefg"
+  config.oauth_secret   = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
 end


### PR DESCRIPTION
This commit adds a fallback OAuth ID and secret. This will allow the signon-munging script for development to configure signon for this app locally.

It also removes the leading `::` from `GDS::SSO` to make it consistent with other apps and allow the munging script to parse the file correctly.