### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -29,6 +29,11 @@ class GovUkContentApi < Sinatra::Application
     content_type :json
   end
 
+  get '/healthcheck' do
+    status 200
+    body 'OK'
+  end
+
   get "/local_authorities.json" do
     set_expiry LONG_CACHE_TIME
     custom_410


### PR DESCRIPTION
This will help us stop icinga from reporting errors while we are turning
this off.

Trello: https://trello.com/c/2MF97xce/154-retire-content-api